### PR TITLE
linux_3.4: removed all kernel module references (resolves #8)

### DIFF
--- a/recipes-kernel/linux/linux_3.4.bb
+++ b/recipes-kernel/linux/linux_3.4.bb
@@ -16,20 +16,8 @@ MACHINE_KERNEL_PR_append = "a"
 
 SRC_URI += "git://github.com/linux-sunxi/linux-sunxi.git;branch=sunxi-3.4;protocol=git \
         file://defconfig \
-	file://screen.conf \	 
-	file://spdif.conf \
-	file://sata.conf \
-	file://wifi.conf \
         "
 
 S = "${WORKDIR}/git"
-
-do_install_append () {
-  install -d ${D}${sysconfdir}/modules-load.d
-  install -m 0755 ${WORKDIR}/spdif.conf ${D}${sysconfdir}/modules-load.d/screen.conf
-  install -m 0755 ${WORKDIR}/spdif.conf ${D}${sysconfdir}/modules-load.d/spdif.conf
-  install -m 0755 ${WORKDIR}/sata.conf ${D}${sysconfdir}/modules-load.d/sata.conf
-  install -m 0755 ${WORKDIR}/wifi.conf ${D}${sysconfdir}/modules-load.d/wifi.conf
-}
 
 INSANE_SKIP_kernel-dev = "debug-files debug-deps arch"


### PR DESCRIPTION
Removed all kernel module references - should be put in machine.conf file instead.
