### PR TITLE
sdcard_image-sunxi.bbclass: fixed .xz check

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -75,7 +75,7 @@ IMAGE_CMD_sunxi-sdimg () {
 	# Burn Partitions
 	dd if=${WORKDIR}/boot.img of=${SDIMG} conv=notrunc seek=1 bs=$(expr ${IMAGE_ROOTFS_ALIGNMENT} \* 1024) && sync && sync
 	# If SDIMG_ROOTFS_TYPE is a .xz file use xzcat
-	if [[ "$SDIMG_ROOTFS_TYPE" == *.xz ]]
+	if echo "${SDIMG_ROOTFS_TYPE}" | egrep -q "*\.xz"
 	then
 		xzcat ${SDIMG_ROOTFS} | dd of=${SDIMG} conv=notrunc seek=1 bs=$(expr 1024 \* ${BOOT_SPACE_ALIGNED} + ${IMAGE_ROOTFS_ALIGNMENT} \* 1024) && sync && sync
 	else


### PR DESCRIPTION
.xz check was relying on a bash check that was not working, returning "]] : not found" error.
Replaced that check with an sh-compatible check, from https://github.com/djwillis/meta-raspberrypi/blob/master/classes/sdcard_image-rpi.bbclass
