### PR TITLE
gst-plugin-cedar: import PoC gstreamer 0.10 plugin

### DIFF
--- a/recipes-multimedia/gstreamer/gst-plugin-cedar_git.bb
+++ b/recipes-multimedia/gstreamer/gst-plugin-cedar_git.bb
@@ -1,0 +1,23 @@
+SUMMARY = "CedarX Hardware Encoding GStreamer plug-in"
+SECTION = "multimedia"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+HOMEPAGE = "http://github.com/ebutera/gst-plugin-cedar"
+DEPENDS = "gstreamer gst-plugins-base"
+
+inherit autotools pkgconfig
+
+# 0.10.1 Initial Import
+SRCREV = "908987a74d341be1376895023698667892fe5569"
+
+SRC_URI = "git://github.com/ebutera/gst-plugin-cedar.git"
+
+PV = "0.10.1+git${SRCPV}"
+PR = "r1"
+
+S = "${WORKDIR}/git"
+
+FILES_${PN} += "${libdir}/gstreamer-0.10/*.so"
+FILES_${PN}-dbg += "${libdir}/gstreamer-0.10/.debug"
+FILES_${PN}-dev += "${libdir}/gstreamer-0.10/*.la"
+FILES_${PN}-staticdev += "${libdir}/gstreamer-0.10/*.a"


### PR DESCRIPTION
GStreamer 0.10 plugin for Cedar H264 hardware encoding with no
binary blobs.

Based on PoC h264 encoder by Jens Kuske:
https://github.com/jemk/cedrus/tree/master/h264enc

Tested on OLinuXino A20 micro, kernel sunxi-3.4

Signed-off-by: Enrico Butera ebutera@users.berlios.de
