### PR TITLE
sunxi-mali: overhaul recipe

### DIFF
--- a/recipes-graphics/libgles/sunxi-mali_git.bb
+++ b/recipes-graphics/libgles/sunxi-mali_git.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "libGLES for the A10/A13 Allwinner processor with Mali 400 (X11)"
+
 LICENSE = "proprietary-binary"
-
-INC_PR = "r5"
-
 LIC_FILES_CHKSUM = "file://README;md5=a103ac69c166fcd98a67a9917dd7affd"
 
 COMPATIBLE_MACHINE = "(mele|meleg|cubieboard|cubieboard2|cubietruck|olinuxino-a13|olinuxino-a20)"
@@ -14,18 +12,13 @@ DEPENDS = "virtual/libx11 libxau libxdmcp libdrm dri2proto libdri2"
 EXCLUDE_FROM_WORLD = "1"
 PROVIDES = "virtual/libgles1 virtual/libgles2 virtual/egl"
 
-RPROVIDES_${PN} += "libEGL.so libGLESv2.so libGLES_CM.so libUMP.so libMali.so"
-
 inherit distro_features_check
 REQUIRED_DISTRO_FEATURES = "opengl"
 
-SRCREV_pn-${PN} = "0809383f9d3ee2575da52262a639ddd6464a641f"
-SRC_URI = "gitsm://github.com/linux-sunxi/sunxi-mali.git;protocol=http"
+SRCREV_pn-${PN} = "997139453d869b4dc2e7507b6a78f27d7f191e28"
+SRC_URI = "gitsm://github.com/linux-sunxi/sunxi-mali.git"
 
 S = "${WORKDIR}/git"
-
-# These are closed binaries generated elsewhere so don't check ldflags & text relocations
-INSANE_SKIP_${PN} = "ldflags textrel"
 
 do_configure() {
          DESTDIR=${D}/ VERSION=r3p0 ABI=armhf EGL_TYPE=x11 make config
@@ -38,10 +31,12 @@ do_install() {
     make libdir=${D}${libdir}/ includedir=${D}${includedir}/ install
     make libdir=${D}${libdir}/ includedir=${D}${includedir}/ install -C include
 
-    # Fix .so name and create symlinks, binary package provides .so wich can't be included directly in package
+    # Fix .so name and create symlinks, binary package provides .so wich can't be included directly in package without triggering the 'dev-so' QA check
+    # Packages like xf86-video-fbturbo dlopen() libUMP.so, so we do need to ship the .so files in ${PN}
 
     mv ${D}${libdir}/libMali.so ${D}${libdir}/libMali.so.3
     ln -sf libMali.so.3 ${D}${libdir}/libMali.so
+    ln -sf libUMP.so.3 ${D}${libdir}/libUMP.so
 
     for flib in libEGL.so.1.4 libGLESv1_CM.so.1.1 libGLESv2.so.2.0 ; do
         rm ${D}${libdir}/$flib
@@ -49,3 +44,8 @@ do_install() {
     done
 }
 
+# Packages like xf86-video-fbturbo dlopen() libUMP.so, so we do need to ship the .so files in ${PN}
+FILES_${PN} += "${libdir}/lib*.so"
+FILES_${PN}-dev = "${includedir}"
+# These are closed binaries generated elsewhere so don't check ldflags & text relocations
+INSANE_SKIP_${PN} = "dev-so ldflags textrel"


### PR DESCRIPTION
The most important change is shipping the .so files in ${PN}, this is
needed for things like xf86-video-fbturbo to work properly. Also disable
the QA check this triggers.

Other fixes include:
- make recipe conform to OE style guide
- update to latest git
- remove unused INC_PR
- RPROVIDES_\* is about packages, not about files, remove it
- Use default git protocol ('git') instead of 'http', which isn't
  officially supported by github
- Add libUMP.so symlink for xf86-video-fbturbo

Runtime tested on olinuxino-a13/Angstrom

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
