### PR TITLE
classes/sdcard_image-sunxi: use absolute path to rootfs

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -25,7 +25,7 @@ IMAGE_ROOTFS_ALIGNMENT = "2048"
 
 # Use an uncompressed ext3 by default as rootfs
 SDIMG_ROOTFS_TYPE ?= "ext3"
-SDIMG_ROOTFS = "${IMAGE_NAME}.rootfs.${SDIMG_ROOTFS_TYPE}"
+SDIMG_ROOTFS = "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.${SDIMG_ROOTFS_TYPE}"
 
 IMAGE_DEPENDS_sunxi-sdimg += " \
 			parted-native \


### PR DESCRIPTION
I was getting an SD card image with the root partition being all zeros unless the rootfs is specified using an absolute path.
