### PR TITLE
sdcard_image-sunxi.bbclass: adding ext3 dependency (resolves #46)

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -13,6 +13,8 @@ inherit image_types
 #
 #
 
+# This image depends on ext3 image
+IMAGE_TYPEDEP_sunxi-sdimg = "ext3"
 
 # Boot partition volume id
 BOOTDD_VOLUME_ID ?= "${MACHINE}"


### PR DESCRIPTION
Without this explicit dependency,
a race condition would be present between the generation of the sd image
and the generation of the ext3 file,
which leads to corrupt SD images in some circumstances.

Based on meta-raspberrypi commit https://github.com/djwillis/meta-raspberrypi/commit/a760ea5fa293a958ebcf1e5af0e6aa4518de4639
