### PR TITLE
sdcard_image-sunxi.bbclass: make sunxi-sdimg image dependent on rootfs type

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -13,8 +13,8 @@ inherit image_types
 #
 #
 
-# This image depends on ext3 image
-IMAGE_TYPEDEP_sunxi-sdimg = "ext3"
+# This image depends on the rootfs image
+IMAGE_TYPEDEP_sunxi-sdimg = "${SDIMG_ROOTFS_TYPE}"
 
 # Boot partition volume id
 BOOTDD_VOLUME_ID ?= "${MACHINE}"


### PR DESCRIPTION
The rootfs may be using a filesystem type other than ext3 so it should
not be hardcoded.

Signed-off-by: Jonathan Liu net147@gmail.com
