### PR TITLE
machines: sync u-boot config name with boards.cfg

### DIFF
--- a/conf/machine/cubieboard.conf
+++ b/conf/machine/cubieboard.conf
@@ -9,7 +9,7 @@ require conf/machine/include/tune-cortexa8.inc
 require conf/machine/include/sunxi.inc
 require conf/machine/include/sunxi-mali.inc
 
-UBOOT_MACHINE = "cubieboard"
+UBOOT_MACHINE = "Cubieboard_config"
 UBOOT_ENTRYPOINT = "0x40008000"
 UBOOT_LOADADDRESS = "0x40008000"
 

--- a/conf/machine/cubieboard2.conf
+++ b/conf/machine/cubieboard2.conf
@@ -9,7 +9,7 @@ require conf/machine/include/tune-cortexa7.inc
 require conf/machine/include/sunxi.inc
 require conf/machine/include/sunxi-mali.inc
 
-UBOOT_MACHINE = "cubieboard2"
+UBOOT_MACHINE = "Cubieboard2_config"
 UBOOT_ENTRYPOINT = "0x40008000"
 UBOOT_LOADADDRESS = "0x40008000"
 

--- a/conf/machine/cubietruck.conf
+++ b/conf/machine/cubietruck.conf
@@ -9,7 +9,7 @@ require conf/machine/include/tune-cortexa7.inc
 require conf/machine/include/sunxi.inc
 require conf/machine/include/sunxi-mali.inc
 
-UBOOT_MACHINE = "cubietruck"
+UBOOT_MACHINE = "Cubietruck_config"
 UBOOT_ENTRYPOINT = "0x40008000"
 UBOOT_LOADADDRESS = "0x40008000"
 

--- a/conf/machine/mele.conf
+++ b/conf/machine/mele.conf
@@ -9,7 +9,7 @@ require conf/machine/include/tune-cortexa8.inc
 require conf/machine/include/sunxi.inc
 require conf/machine/include/sunxi-mali.inc
 
-UBOOT_MACHINE = "mele_a1000"
+UBOOT_MACHINE = "Mele_A1000_config"
 UBOOT_ENTRYPOINT = "0x40008000"
 UBOOT_LOADADDRESS = "0x40008000"
 

--- a/conf/machine/meleg.conf
+++ b/conf/machine/meleg.conf
@@ -9,7 +9,7 @@ require conf/machine/include/tune-cortexa8.inc
 require conf/machine/include/sunxi.inc
 require conf/machine/include/sunxi-mali.inc
 
-UBOOT_MACHINE = "mele_a1000g"
+UBOOT_MACHINE = "Mele_A1000G_config"
 UBOOT_ENTRYPOINT = "0x40008000"
 UBOOT_LOADADDRESS = "0x40008000"
 

--- a/conf/machine/olinuxino-a10.conf
+++ b/conf/machine/olinuxino-a10.conf
@@ -11,7 +11,7 @@ require conf/machine/include/sunxi.inc
 require conf/machine/include/sunxi-mali.inc
 
 
-UBOOT_MACHINE = "a10-olinuxino-lime"
+UBOOT_MACHINE = "A10-OLinuXino-Lime_config"
 UBOOT_ENTRYPOINT = "0x40008000"
 UBOOT_LOADADDRESS = "0x40008000"
 

--- a/conf/machine/olinuxino-a10s.conf
+++ b/conf/machine/olinuxino-a10s.conf
@@ -10,7 +10,7 @@ require conf/machine/include/tune-cortexa8.inc
 require conf/machine/include/sunxi.inc
 
 
-UBOOT_MACHINE = "a10s-olinuxino-m"
+UBOOT_MACHINE = "A10s-OLinuXino-M_config"
 UBOOT_ENTRYPOINT = "0x40008000"
 UBOOT_LOADADDRESS = "0x40008000"
 

--- a/conf/machine/olinuxino-a13.conf
+++ b/conf/machine/olinuxino-a13.conf
@@ -10,7 +10,7 @@ require conf/machine/include/tune-cortexa8.inc
 require conf/machine/include/sunxi.inc
 require conf/machine/include/sunxi-mali.inc
 
-UBOOT_MACHINE = "a13-olinuxino"
+UBOOT_MACHINE = "A13-OLinuXino_config"
 UBOOT_ENTRYPOINT = "0x40008000"
 UBOOT_LOADADDRESS = "0x40008000"
 

--- a/conf/machine/olinuxino-a20.conf
+++ b/conf/machine/olinuxino-a20.conf
@@ -7,7 +7,7 @@ require conf/machine/include/tune-cortexa7.inc
 require conf/machine/include/sunxi.inc
 require conf/machine/include/sunxi-mali.inc
 
-UBOOT_MACHINE = "a20-olinuxino_micro"
+UBOOT_MACHINE = "A20-OLinuXino_MICRO_config"
 UBOOT_ENTRYPOINT = "0x40008000"
 UBOOT_LOADADDRESS = "0x40008000"
 


### PR DESCRIPTION
Recent u-boots (e.g. 2014.04-rc) need the _config appended to work, so
add that and sync the names with boards.cfg as well.

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
