### PR TITLE
linux-3.4: update to 3.4.90

### DIFF
--- a/recipes-kernel/linux/linux_3.4.bb
+++ b/recipes-kernel/linux/linux_3.4.bb
@@ -14,8 +14,12 @@ SRCREV_pn-${PN} = "e37d760b363888f3a65cd6455c99a75cac70a7b8"
 MACHINE_KERNEL_PR_append = "a"
 
 SRC_URI += "git://github.com/linux-sunxi/linux-sunxi.git;branch=sunxi-3.4;protocol=git \
+        http://archlinuxarm.org/builder/src/0001-cgroup-add-xattr-support-sunxi.patch;name=cgroup-patch \
         file://defconfig \
         "
+
+SRC_URI[cgroup-patch.md5sum] = "4aa5087e3396f3179b61ccd478e9e604"
+SRC_URI[cgroup-patch.sha256sum] = "f9f9cb55eb6f8abf322830afd7a5f4a090e539add75e0ed1f1016b5351a9b533"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This fixes an issue with systemd >= 213, where it can't mount a
filesystem in /sys/fs/cgroups/systemd because sysfs didn't support
xattr.

Signed-off-by: Dan McGregor dan.mcgregor@usask.ca
