### PR TITLE
Append the shortened git revision to the u-boot version

### DIFF
--- a/conf/machine/include/sunxi.inc
+++ b/conf/machine/include/sunxi.inc
@@ -14,3 +14,5 @@ IMAGE_CLASSES += "sdcard_image-sunxi"
 IMAGE_FSTYPES += "ext3 tar.gz sunxi-sdimg"
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
+
+UBOOT_LOCALVERSION = "-g${@d.getVar('SRCPV', True).partition('+')[2][0:7]}"


### PR DESCRIPTION
This add the first 7 characters of the git sha-1 to the compiled in
u-boot version.

With  this change the serial console displays the following version information:

U-Boot 2014.04-gee425f9 (Oct 01 2014 - 22:20:35) Allwinner Technology

Without the version looks like this:

U-Boot 2014.04 (Oct 01 2014 - 21:55:57) Allwinner Technology

Signed-off-by: Christian Ege k4230r6@gmail.com
