### PR TITLE
Support for mainline u-boot 2015.01rc4

### DIFF
--- a/conf/machine/include/sunxi.inc
+++ b/conf/machine/include/sunxi.inc
@@ -14,5 +14,3 @@ IMAGE_CLASSES += "sdcard_image-sunxi"
 IMAGE_FSTYPES += "ext3 tar.gz sunxi-sdimg"
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
-
-UBOOT_LOCALVERSION = "-g${@d.getVar('SRCPV', True).partition('+')[2][0:7]}"

--- a/conf/machine/olinuxino-a20lime2.conf
+++ b/conf/machine/olinuxino-a20lime2.conf
@@ -1,0 +1,16 @@
+#@TYPE: Machine
+#@NAME: Olimex A20-OLinuXino Lime2 Board
+#@DESCRIPTION: Machine configuration for the Olimex A20-OLinuXino Lime2 Board, based on Allwinner A20 CPU
+#https://github.com/OLIMEX/OLINUXINO
+
+require conf/machine/include/tune-cortexa7.inc
+require conf/machine/include/sunxi.inc
+require conf/machine/include/sunxi-mali.inc
+
+UBOOT_MACHINE = "A20-OLinuXino-Lime2_config"
+UBOOT_ENTRYPOINT = "0x40008000"
+UBOOT_LOADADDRESS = "0x40008000"
+
+SERIAL_CONSOLE = "115200 ttyS0"
+
+MACHINE_FEATURES = "kernel26 screen apm usbgadget usbhost vfat alsa"

--- a/recipes-bsp/sunxi-board-fex/sunxi-board-fex.bb
+++ b/recipes-bsp/sunxi-board-fex/sunxi-board-fex.bb
@@ -9,7 +9,7 @@ PR = "r0"
 
 SRC_URI = "git://github.com/linux-sunxi/sunxi-boards.git;protocol=git"
 # Increase PV with SRCREV change
-SRCREV = "442f0669fec0689dda3e529bcd8be9e554868b5f"
+SRCREV = "9f46830ba50532d40ff2533c2e59a8fd8c470ade"
 
 S = "${WORKDIR}/git"
 SUNXI_FEX_FILE_mele = "sys_config/a10/mele_a1000.fex"
@@ -20,6 +20,7 @@ SUNXI_FEX_FILE_olinuxino-a13 = "sys_config/a13/a13-olinuxino.fex"
 SUNXI_FEX_FILE_olinuxino-a20 = "sys_config/a20/a20-olinuxino_micro.fex"
 SUNXI_FEX_FILE_olinuxino-a20som = "sys_config/a20/olimex_a20_som.fex"
 SUNXI_FEX_FILE_olinuxino-a20lime = "sys_config/a20/a20-olinuxino_lime.fex"
+SUNXI_FEX_FILE_olinuxino-a20lime2 = "sys_config/a20/a20-olinuxino_lime2.fex"
 SUNXI_FEX_FILE_cubieboard = "sys_config/a10/cubieboard.fex"
 SUNXI_FEX_FILE_cubieboard2 = "sys_config/a20/cubieboard2.fex"
 SUNXI_FEX_FILE_cubietruck= "sys_config/a20/cubietruck.fex"
@@ -55,4 +56,4 @@ do_package_write_rpm[noexec] = "1"
 do_package_write_deb[noexec] = "1"
 do_populate_sysroot[noexec] = "1"
 
-COMPATIBLE_MACHINE = "(mele|meleg|olinuxino-a10s|olinuxino-a10|olinuxino-a13|olinuxino-a20|olinuxino-a20som|olinuxino-a20lime|cubieboard|cubieboard2|cubietruck)"
+COMPATIBLE_MACHINE = "(mele|meleg|olinuxino-a10s|olinuxino-a10|olinuxino-a13|olinuxino-a20|olinuxino-a20som|olinuxino-a20lime|olinuxino-a20lime2|cubieboard|cubieboard2|cubietruck)"

--- a/recipes-bsp/u-boot/u-boot.inc
+++ b/recipes-bsp/u-boot/u-boot.inc
@@ -1,20 +1,21 @@
-DESCRIPTION = "U-Boot - the Universal Boot Loader"
+SUMMARY = "Universal Boot Loader for embedded devices"
 HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"
 SECTION = "bootloaders"
 PROVIDES = "virtual/bootloader"
 
-inherit deploy
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=1707d6db1d42237583f50183a5651ecb \
+                    file://README;beginline=1;endline=22;md5=78b195c11cb6ef63e6985140db7d7bab"
+
+SRC_URI = "git://git.denx.de/u-boot.git;branch=master"
+
+S = "${WORKDIR}/git"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit uboot-config deploy
 
 EXTRA_OEMAKE = 'CROSS_COMPILE=${TARGET_PREFIX} CC="${TARGET_PREFIX}gcc ${TOOLCHAIN_OPTIONS}"'
-
-python () {
-	if not d.getVar("UBOOT_MACHINE", True):
-		PN = d.getVar("PN", True)
-		FILE = os.path.basename(d.getVar("FILE", True))
-		bb.debug(1, "To build %s, see %s for instructions on \
-			     setting up your machine config" % (PN, FILE))
-		raise bb.parse.SkipPackage("because UBOOT_MACHINE is not set")
-}
 
 # Allow setting an additional version string that will be picked up by the
 # u-boot build system and appended to the u-boot version.  If the .scmversion
@@ -37,8 +38,19 @@ SPL_BINARY ?= ""
 SPL_IMAGE ?= "${SPL_BINARY}-${MACHINE}-${PV}-${PR}"
 SPL_SYMLINK ?= "${SPL_BINARY}-${MACHINE}"
 
+# Additional environment variables or a script can be installed alongside
+# u-boot to be used automatically on boot.  This file, typically 'uEnv.txt'
+# or 'boot.scr', should be packaged along with u-boot as well as placed in the
+# deploy directory.  Machine configurations needing one of these files should
+# include it in the SRC_URI and set the UBOOT_ENV parameter.
+UBOOT_ENV_SUFFIX ?= "txt"
+UBOOT_ENV ?= ""
+UBOOT_ENV_BINARY ?= "${UBOOT_ENV}.${UBOOT_ENV_SUFFIX}"
+UBOOT_ENV_IMAGE ?= "${UBOOT_ENV}-${MACHINE}-${PV}-${PR}.${UBOOT_ENV_SUFFIX}"
+UBOOT_ENV_SYMLINK ?= "${UBOOT_ENV}-${MACHINE}.${UBOOT_ENV_SUFFIX}"
+
 do_compile () {
-	if [ "${@base_contains('DISTRO_FEATURES', 'ld-is-gold', 'ld-is-gold', '', d)}" = "ld-is-gold" ] ; then
+	if [ "${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', 'ld-is-gold', '', d)}" = "ld-is-gold" ] ; then
 		sed -i 's/$(CROSS_COMPILE)ld$/$(CROSS_COMPILE)ld.bfd/g' config.mk
 	fi
 
@@ -71,10 +83,15 @@ do_install () {
         install ${S}/${SPL_BINARY} ${D}/boot/${SPL_IMAGE}
         ln -sf ${SPL_IMAGE} ${D}/boot/${SPL_BINARY}
     fi
+
+    if [ "x${UBOOT_ENV}" != "x" ]
+    then
+        install ${WORKDIR}/${UBOOT_ENV_BINARY} ${D}/boot/${UBOOT_ENV_IMAGE}
+        ln -sf ${UBOOT_ENV_IMAGE} ${D}/boot/${UBOOT_ENV_BINARY}
+    fi
 }
 
 FILES_${PN} = "/boot ${sysconfdir}"
-FILESPATH =. "${FILE_DIRNAME}/u-boot-git/${MACHINE}:"
 
 do_deploy () {
     install -d ${DEPLOYDIR}
@@ -91,6 +108,14 @@ do_deploy () {
         rm -f ${DEPLOYDIR}/${SPL_BINARY} ${DEPLOYDIR}/${SPL_SYMLINK}
         ln -sf ${SPL_IMAGE} ${DEPLOYDIR}/${SPL_BINARY}
         ln -sf ${SPL_IMAGE} ${DEPLOYDIR}/${SPL_SYMLINK}
+    fi
+
+    if [ "x${UBOOT_ENV}" != "x" ]
+    then
+        install ${WORKDIR}/${UBOOT_ENV_BINARY} ${DEPLOYDIR}/${UBOOT_ENV_IMAGE}
+        rm -f ${DEPLOYDIR}/${UBOOT_ENV_BINARY} ${DEPLOYDIR}/${UBOOT_ENV_SYMLINK}
+        ln -sf ${UBOOT_ENV_IMAGE} ${DEPLOYDIR}/${UBOOT_ENV_BINARY}
+        ln -sf ${UBOOT_ENV_IMAGE} ${DEPLOYDIR}/${UBOOT_ENV_SYMLINK}
     fi
 }
 

--- a/recipes-bsp/u-boot/u-boot_git.bb
+++ b/recipes-bsp/u-boot/u-boot_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 # No patches for other machines yet
-COMPATIBLE_MACHINE = "(mele|meleg|olinuxino-a13|olinuxino-a10s|olinuxino-a10|olinuxino-a20|olinuxino-a20som|olinuxino-a20lime|cubieboard|cubieboard2|cubietruck)"
+COMPATIBLE_MACHINE = "(mele|meleg|olinuxino-a13|olinuxino-a10s|olinuxino-a10|olinuxino-a20|olinuxino-a20som|olinuxino-a20lime|olinuxino-a20lime2|cubieboard|cubieboard2|cubietruck)"
 
 DEFAULT_PREFERENCE_mele= "1"
 DEFAULT_PREFERENCE_meleg= "1"
@@ -14,15 +14,18 @@ DEFAULT_PREFERENCE_olinuxino-a10= "1"
 DEFAULT_PREFERENCE_olinuxino-a20= "1"
 DEFAULT_PREFERENCE_olinuxino-a20som= "1"
 DEFAULT_PREFERENCE_olinuxino-a20lime= "1"
+DEFAULT_PREFERENCE_olinuxino-a20lime2= "1"
 DEFAULT_PREFERENCE_cubieboard="1"
 DEFAULT_PREFERENCE_cubieboard2="1"
 DEFAULT_PREFERENCE_cubietruck="1"
 
-SRC_URI = "git://github.com/linux-sunxi/u-boot-sunxi.git;protocol=git;branch=sunxi"
+SRC_URI = "git://git.denx.de/u-boot.git;branch=master"
 
 PE = "1"
-PV = "v2014.04+git${SRCPV}"
-SRCREV = "ee425f94b488a4304c136a171bb8fdec0d835032"
+PV = "v2015.01+git${SRCPV}"
+
+# Corresponds to tag v2015.01-rc3
+SRCREV = "125738e819a3b9d15210794b3dcef9f4d9bcf866"
 
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
I've added support for mainline u-boot 2015.01rc4. To boot the regacy 3.4 kernel below manual steps to be preformed after build.

1. support I'm building for lime2 board, add below line to the build/tmp/work/olinuxino_a20lime2-poky-linux-gnueabi/u-boot/u-bootxxx/git/configs/A20-OLinuXino-Lime2_defconfig
CONFIG_OLD_SUNXI_KERNEL_COMPAT=y
+S:CONFIG_OLD_SUNXI_KERNEL_COMPAT=y

2. bitbake -c compile u-boot -f
3. bitbake -c deploy u-boot -f

Now, it's able to boot the leagacy 3.4.90 kernel, I've verified this on Lime2 Board.

by default, It boots mainline linux without any problem. however, mainline kernel support is yet to be added.

