### PR TITLE
linux.inc: support building with B != S which is default now (resolves #...

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -25,15 +25,15 @@ kernel_configure_variable() {
 	CONF_SED_SCRIPT="$CONF_SED_SCRIPT /CONFIG_$1[ =]/d;"
 	if test "$2" = "n"
 	then
-		echo "# CONFIG_$1 is not set" >> ${S}/.config
+		echo "# CONFIG_$1 is not set" >> ${B}/.config
 	else
-		echo "CONFIG_$1=$2" >> ${S}/.config
+		echo "CONFIG_$1=$2" >> ${B}/.config
 	fi
 }
 
 do_configure_prepend() {
 	# Clean .config
-	echo "" > ${S}/.config
+	echo "" > ${B}/.config
 	CONF_SED_SCRIPT=""
 
 	# oabi / eabi support
@@ -108,9 +108,9 @@ do_configure_prepend() {
 
 	# Keep this the last line
 	# Remove all modified configs and add the rest to .config
-	sed -e "${CONF_SED_SCRIPT}" < '${WORKDIR}/defconfig' >> '${S}/.config'
+	sed -e "${CONF_SED_SCRIPT}" < '${WORKDIR}/defconfig' >> '${B}/.config'
 
-	yes '' | oe_runmake oldconfig
+	yes '' | oe_runmake -C ${S} O=${B} oldconfig
 }
 
 # Automatically depend on lzop-native if CONFIG_KERNEL_LZO is enabled


### PR DESCRIPTION
...79)

Based on https://github.com/openembedded/meta-openembedded/commit/fc7132ede27ac67669448d3d2845ce7d46c6a1ee

Fixes following do_configure error
  | NOTE: make oldconfig
  | make: *** No rule to make target `oldconfig'.  Stop.
  | ERROR: oe_runmake failed

Signed-off-by: Kristof Robot <krirobo@gmail.com>