### PR TITLE
sdcard_image-sunxi.bbclass: reverting to deploy dir instead of staging d...

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -38,7 +38,7 @@ IMAGE_DEPENDS_sunxi-sdimg += " \
                         sunxi-board-fex \
 			"
 
-rootfs[depends] += "sunxi-board-fex:do_deploy"
+rootfs[depends] += "virtual/kernel:do_deploy sunxi-board-fex:do_deploy"
 
 # SD card image name
 SDIMG = "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.sunxi-sdimg"
@@ -67,7 +67,7 @@ IMAGE_CMD_sunxi-sdimg () {
 	# Create a vfat image with boot files
 	BOOT_BLOCKS=$(LC_ALL=C parted -s ${SDIMG} unit b print | awk '/ 1 / { print substr($4, 1, length($4 -1)) / 512 /2 }')
 	mkfs.vfat -n "${BOOTDD_VOLUME_ID}" -S 512 -C ${WORKDIR}/boot.img $BOOT_BLOCKS
-	mcopy -i ${WORKDIR}/boot.img -s ${STAGING_DIR_HOST}/usr/src/kernel/${KERNEL_IMAGETYPE} ::uImage
+	mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${MACHINE}.bin ::uImage
 	if [ -e "${DEPLOY_DIR_IMAGE}/fex.bin" ]
 	then
 		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/fex.bin ::script.bin


### PR DESCRIPTION
...ir (resolves #81)

To resolve the race condition described in #15,
a patch was introduced to use the kernel source from staging dir
rather than deploy dir.

After the reorganization of the kernel source location by
https://github.com/openembedded/oe-core/commit/6a1ff0e7eacef595738f2fed086986fd622ec32a
this no longer works.

Reverting the previous patch,
and introducing explicit rootfs dependency instead.

Signed-off-by: Kristof Robot <krirobo@gmail.com>