### PR TITLE
olinuxino-a20: fix KERNEL_DEVICETREE

### DIFF
--- a/conf/machine/olinuxino-a20.conf
+++ b/conf/machine/olinuxino-a20.conf
@@ -5,6 +5,6 @@
 
 require conf/machine/include/sun7i.inc
 
-KERNEL_DEVICETREE = "sun7i-a20-olinuxino-lime.dtb"
+KERNEL_DEVICETREE = "sun7i-a20-olinuxino-micro.dtb"
 UBOOT_MACHINE = "A20-OLinuXino_MICRO_config"
 SUNXI_FEX_FILE = "sys_config/a20/a20-olinuxino_micro.fex"


### PR DESCRIPTION
Fixes a typo in KERNEL_DEVICETREE.