### PR TITLE
kernel: use tar.xz, git optional

### DIFF
--- a/recipes-kernel/linux/linux_4.1.3.bb
+++ b/recipes-kernel/linux/linux_4.1.3.bb
@@ -14,9 +14,9 @@ RDEPENDS_kernel-base += "kernel-devicetree"
 
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 	
-PV = "4.0.5"
-SRCREV_pn-${PN} = "be4cb235441a691ee63ba5e00843a9c210be5b8a"
-SRC_URI += "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=git;branch=linux-4.0.y \
+SRC_URI[md5sum] = "96c2c77b1c54ba01cfd8fc2d13fbf828"
+SRC_URI[sha256sum] = "96dd2c30984408a8a2211463618c3564514239f1e4335f6bc461c4b9a9bae30b"
+
+SRC_URI += "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz \
         file://defconfig \
         "
-S = "${WORKDIR}/git"

--- a/recipes-kernel/linux/linux_git.bb
+++ b/recipes-kernel/linux/linux_git.bb
@@ -19,7 +19,7 @@ DEFAULT_PREFERENCE = "-1"
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 	
 # 4.2 rc4
-PV = "4.2"
+PV = "4.1+4.2rc4.git${SRCPV}"
 SRCREV_pn-${PN} = "cbfe8fa6cd672011c755c3cd85c9ffd4e2d10a6f"
 
 SRC_URI += "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=git;branch=master \

--- a/recipes-kernel/linux/linux_git.bb
+++ b/recipes-kernel/linux/linux_git.bb
@@ -12,11 +12,17 @@ require linux.inc
 # Pull in the devicetree files into the rootfs
 RDEPENDS_kernel-base += "kernel-devicetree"
 
+# Default is to use stable kernel version
+# If you want to use latest git version set to "1"
+DEFAULT_PREFERENCE = "-1" 
+
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 	
-PV = "4.1.2"
-SRCREV_pn-${PN} = "5cf9896dc5c72a6c68c36140568b755f697f7760"
-SRC_URI += "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=git;branch=linux-4.1.y \
+# 4.2 rc4
+PV = "4.2"
+SRCREV_pn-${PN} = "cbfe8fa6cd672011c755c3cd85c9ffd4e2d10a6f"
+
+SRC_URI += "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=git;branch=master \
         file://defconfig \
         "
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Per default use stable kernel by downloading tar.xz (fast download).
Optional use latest mainline kernel by git fetch. Must be enabled
in linux_git.bb by setting DEFAULT_PREFERENCE to "1".

Signed-off-by: Jens Lucius <info@jenslucius.com>