### PR TITLE
Use correct u-boot name for meleg

### DIFF
--- a/conf/machine/meleg.conf
+++ b/conf/machine/meleg.conf
@@ -4,5 +4,5 @@
 
 require conf/machine/include/sun4i.inc
 
-UBOOT_MACHINE = "Mele_A1000G_config"
+UBOOT_MACHINE = "Mele_A1000G_quad"
 SUNXI_FEX_FILE = "sys_config/a10/mele_a1000g.fex"

--- a/conf/machine/meleg.conf
+++ b/conf/machine/meleg.conf
@@ -4,5 +4,5 @@
 
 require conf/machine/include/sun4i.inc
 
-UBOOT_MACHINE = "Mele_A1000G_quad"
+UBOOT_MACHINE = "Mele_A1000G_quad_config"
 SUNXI_FEX_FILE = "sys_config/a10/mele_a1000g.fex"

--- a/recipes-bsp/u-boot/u-boot-sunxi.bb
+++ b/recipes-bsp/u-boot/u-boot-sunxi.bb
@@ -16,6 +16,7 @@ DEFAULT_PREFERENCE_sun7i="1"
 # Sunxi U-Boot uses different names for some boards
 UBOOT_MACHINE_olinuxino-a20 = "A20-OLinuXino-Micro_config"
 UBOOT_MACHINE_olinuxino-a10s = "A10s-OLinuXino-Micro_config"
+UBOOT_MACHINE_meleg = "Mele_A1000G_config"
 
 SRC_URI = "git://github.com/linux-sunxi/u-boot-sunxi.git;protocol=git;branch=sunxi"
 


### PR DESCRIPTION
Mainline u-boot uses a different name for the configuration for the Mele G.
Use correct name for mainline, use old name for sunxi u-boot.