### PR TITLE
linux-sunxi: add patches for gcc5

### DIFF
--- a/recipes-kernel/linux/linux-sunxi/0001-compiler-gcc5.patch
+++ b/recipes-kernel/linux/linux-sunxi/0001-compiler-gcc5.patch
@@ -1,0 +1,71 @@
+Index: git/include/linux/compiler-gcc5.h
+===================================================================
+--- git/include/linux/compiler-gcc5.h    2015-09-19 20:11:27.999423338 +0200
++++ git/include/linux/compiler-gcc5.h    2015-09-23 10:26:05.000000000 +0200
+@@ -0,0 +1,66 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc5.h> directly, include <linux/compiler.h> instead."
++#endif
++
++#define __used				__attribute__((__used__))
++#define __must_check			__attribute__((warn_unused_result))
++#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
++
++/* Mark functions as cold. gcc will assume any path leading to a call
++   to them will be unlikely.  This means a lot of manual unlikely()s
++   are unnecessary now for any paths leading to the usual suspects
++   like BUG(), printk(), panic() etc. [but let's keep them for now for
++   older compilers]
++
++   Early snapshots of gcc 4.3 don't support this and we can't detect this
++   in the preprocessor, but we can live with this because they're unreleased.
++   Maketime probing would be overkill here.
++
++   gcc also has a __attribute__((__hot__)) to move hot functions into
++   a special section, but I don't see any sense in this right now in
++   the kernel context */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible __attribute__((externally_visible))
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ * Fixed in GCC 4.8.2 and later versions.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#define __HAVE_BUILTIN_BSWAP16__
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */

--- a/recipes-kernel/linux/linux-sunxi/0002-use-static-inline-in-ARM-ftrace.patch
+++ b/recipes-kernel/linux/linux-sunxi/0002-use-static-inline-in-ARM-ftrace.patch
@@ -1,0 +1,50 @@
+From ef4fea130eeb70eff4f3a549fd3f6e9b11437550 Mon Sep 17 00:00:00 2001
+From: ZaneZam <cyxman@yahoo.com>
+Date: Thu, 26 Mar 2015 14:50:10 +0100
+Subject: [PATCH] arm: LLVMLinux: use static inline in ARM ftrace.h
+
+With compilers which follow the C99 standard (like modern versions of gcc and
+clang), "extern inline" does the wrong thing (emits code for an externally
+linkable version of the inline function). In this case using static inline
+and removing the NULL version of return_address in return_address.c does
+the right thing.
+
+Signed-off-by: Behan Webster <behanw@converseincode.com>
+Reviewed-by: Mark Charlebois <charlebm@gmail.com>
+
+source: http://www.serverphorums.com/read.php?12,880351,880351#msg-880351
+---
+ arch/arm/include/asm/ftrace.h    | 2 +-
+ arch/arm/kernel/return_address.c | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/include/asm/ftrace.h b/arch/arm/include/asm/ftrace.h
+index f89515a..2bb8cac 100644
+--- a/arch/arm/include/asm/ftrace.h
++++ b/arch/arm/include/asm/ftrace.h
+@@ -45,7 +45,7 @@ void *return_address(unsigned int);
+ 
+ #else
+ 
+-extern inline void *return_address(unsigned int level)
++static inline void *return_address(unsigned int level)
+ {
+ 	return NULL;
+ }
+diff --git a/arch/arm/kernel/return_address.c b/arch/arm/kernel/return_address.c
+index f1aef84..49477f0 100644
+--- a/arch/arm/kernel/return_address.c
++++ b/arch/arm/kernel/return_address.c
+@@ -62,10 +62,12 @@ void *return_address(unsigned int level)
+ /* #warning "TODO: return_address should use unwind tables" */
+ #endif
+ 
++/*
+ void *return_address(unsigned int level)
+ {
+ 	return NULL;
+ }
++*/
+ 
+ #endif /* if defined(CONFIG_FRAME_POINTER) && !defined(CONFIG_ARM_UNWIND) / else */
+ 

--- a/recipes-kernel/linux/linux-sunxi_3.4.bb
+++ b/recipes-kernel/linux/linux-sunxi_3.4.bb
@@ -13,6 +13,8 @@ MACHINE_KERNEL_PR_append = "a"
 
 SRC_URI += "git://github.com/linux-sunxi/linux-sunxi.git;branch=sunxi-3.4;protocol=git \
         http://archlinuxarm.org/builder/src/0001-cgroup-add-xattr-support-sunxi.patch;name=cgroup-patch \
+        file://0001-compiler-gcc5.patch \
+        file://0002-use-static-inline-in-ARM-ftrace.patch
         file://defconfig \
         "
 


### PR DESCRIPTION
The linux-sunxi 3.4 kernel could not be compiled with gcc5 (which
is standard in master now). Add two patches to make it compile again.

- Add missing compiler-gcc5.h
- Fix "multiple definition of `return_address'" errors

Open issue: All realtek wifi drivers fail to compile. Because of this
keep info to switch back to gcc4 in readme.

Signed-off-by: Jens Lucius <info@jenslucius.com>