### PR TITLE
linux-sunxi_3.4.bb: add line continuation

### DIFF
--- a/recipes-kernel/linux/linux-sunxi_3.4.bb
+++ b/recipes-kernel/linux/linux-sunxi_3.4.bb
@@ -14,7 +14,7 @@ MACHINE_KERNEL_PR_append = "a"
 SRC_URI += "git://github.com/linux-sunxi/linux-sunxi.git;branch=sunxi-3.4;protocol=git \
         http://archlinuxarm.org/builder/src/0001-cgroup-add-xattr-support-sunxi.patch;name=cgroup-patch \
         file://0001-compiler-gcc5.patch \
-        file://0002-use-static-inline-in-ARM-ftrace.patch
+        file://0002-use-static-inline-in-ARM-ftrace.patch \
         file://defconfig \
         "
 


### PR DESCRIPTION
ERROR: ParseError at meta-sunxi/recipes-kernel/linux/linux-sunxi_3.4.bb:17:
       unparsed line: SRC_URI

Signed-off-by: Trevor Woerner <twoerner@gmail.com>