### PR TITLE
sunxi-mali: remove opengl requirement

### DIFF
--- a/recipes-graphics/libgles/sunxi-mali_git.bb
+++ b/recipes-graphics/libgles/sunxi-mali_git.bb
@@ -11,9 +11,6 @@ EXCLUDE_FROM_WORLD = "1"
 PROVIDES = "virtual/libgles1 virtual/libgles2 virtual/egl"
 RPROVIDES_${PN} += "libGLESv2.so libEGL.so libGLESv2.so libGLESv1_CM.so libMali.so"
 
-inherit distro_features_check
-REQUIRED_DISTRO_FEATURES = "opengl"
-
 SRCREV_pn-${PN} = "d343311efc8db166d8371b28494f0f27b6a58724"
 SRC_URI = "gitsm://github.com/linux-sunxi/sunxi-mali.git \
            file://0001-Add-EGLSyncKHR-EGLTimeKHR-and-GLChar-definition.patch \


### PR DESCRIPTION
The mali driver supports OpenGL ES and doesn't require OpenGL in any way. It
is completely feasible to install mali and run OpenGL ES-only apps against it
without any need for OpenGL whatsoever.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>