### PR TITLE
Remove sunxi-sdimg dependency on sunxi-board-fex

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -35,7 +35,6 @@ IMAGE_DEPENDS_sunxi-sdimg += " \
 			dosfstools-native \
 			virtual/kernel \
 			virtual/bootloader \
-                        sunxi-board-fex \
 			"
 
 rootfs[depends] += "virtual/kernel:do_deploy sunxi-board-fex:do_deploy"


### PR DESCRIPTION
This allows for machines using only mainline kernel with device tree and no FEX file.
Currently this dependency prevents building the sunxi SD card image for such machines. The copying of the fex.bin file from the deploy directory is conditional on its existence, so this shouldnt introduce any errors for people still using FEX.