### PR TITLE
Remove image dependency on fex for mainline

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -35,10 +35,9 @@ IMAGE_DEPENDS_sunxi-sdimg += " \
 			dosfstools-native \
 			virtual/kernel \
 			virtual/bootloader \
-                        sunxi-board-fex \
 			"
 
-rootfs[depends] += "virtual/kernel:do_deploy sunxi-board-fex:do_deploy"
+rootfs[depends] += "virtual/kernel:do_deploy"
 
 # SD card image name
 SDIMG = "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.sunxi-sdimg"

--- a/recipes-kernel/linux/linux-sunxi_3.4.bb
+++ b/recipes-kernel/linux/linux-sunxi_3.4.bb
@@ -3,7 +3,7 @@ require linux.inc
 DESCRIPTION = "Linux kernel for Allwinner a10/a20 processors"
 
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
-DEPENDS = "sunxi-board-fex"
+RDEPENDS_${PN} += "sunxi-board-fex"
 
 PV = "3.4.104"
 PR = "r1"

--- a/recipes-kernel/linux/linux-sunxi_3.4.bb
+++ b/recipes-kernel/linux/linux-sunxi_3.4.bb
@@ -3,10 +3,11 @@ require linux.inc
 DESCRIPTION = "Linux kernel for Allwinner a10/a20 processors"
 
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
+DEPENDS = "sunxi-board-fex"
 
-PV = "3.4.103"
+PV = "3.4.104"
 PR = "r1"
-SRCREV_pn-${PN} = "9a1cd034181af628d4145202289e1993c1687db6"
+SRCREV_pn-${PN} = "d47d367036be38c5180632ec8a3ad169a4593a88"
 
 MACHINE_KERNEL_PR_append = "a"
 


### PR DESCRIPTION
Remove image dependency on building fex files which are not needed
any more for mainline kernel (replaced by devicetree).
Add dependency for fex to linux-sunxi kernel.
Also update to latest sunxi-linux revision.

Signed-off-by: Jens Lucius <info@jenslucius.com>