### PR TITLE
Basic H3 support

### DIFF
--- a/conf/machine/include/sun8i.inc
+++ b/conf/machine/include/sun8i.inc
@@ -1,0 +1,5 @@
+require conf/machine/include/sunxi.inc
+require conf/machine/include/sunxi-mali.inc
+require conf/machine/include/tune-cortexa7.inc
+
+SOC_FAMILY = "sun8i"

--- a/conf/machine/include/sunxi.inc
+++ b/conf/machine/include/sunxi.inc
@@ -26,7 +26,6 @@ MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
 UBOOT_LOCALVERSION = "-g${@d.getVar('SRCPV', True).partition('+')[2][0:7]}"
 
 UBOOT_ENTRYPOINT ?= "0x40008000"
-UBOOT_LOADADDRESS ?= "0x400080OB00"
 
 SERIAL_CONSOLE ?= "115200 ttyS0"
 MACHINE_FEATURES ?= "alsa apm keyboard rtc serial screen usbgadget usbhost vfat"

--- a/recipes-bsp/sunxi-board-fex/sunxi-board-fex.bb
+++ b/recipes-bsp/sunxi-board-fex/sunxi-board-fex.bb
@@ -7,7 +7,7 @@ DEPENDS = "sunxi-tools-native"
 PV = "1.1+git${SRCPV}"
 PR = "r0"
 
-COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
+COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i)"
 
 SRC_URI = "git://github.com/linux-sunxi/sunxi-boards.git;protocol=git"
 # Increase PV with SRCREV change

--- a/recipes-bsp/u-boot/files/orangepiplus-old-sunxi-kernel-compat.patch
+++ b/recipes-bsp/u-boot/files/orangepiplus-old-sunxi-kernel-compat.patch
@@ -1,0 +1,9 @@
+diff --git a/configs/orangepi_plus_defconfig b/configs/orangepi_plus_defconfig
+index 003a9c6..436738f 100644
+--- a/configs/orangepi_plus_defconfig
++++ b/configs/orangepi_plus_defconfig
+@@ -12,3 +12,4 @@ CONFIG_SPL=y
+ # CONFIG_CMD_FLASH is not set
+ # CONFIG_CMD_FPGA is not set
+ CONFIG_CMD_GPIO=y
++CONFIG_OLD_SUNXI_KERNEL_COMPAT=y

--- a/recipes-bsp/u-boot/files/sun8i/boot.cmd
+++ b/recipes-bsp/u-boot/files/sun8i/boot.cmd
@@ -1,0 +1,5 @@
+setenv machid 1029
+setenv bootargs console=ttyS0,115200 root=/dev/mmcblk0p2 rootwait panic=10
+load mmc 0:1 0x43000000 script.bin
+load mmc 0:1 0x40008000 uImage
+bootm 0x40008000

--- a/recipes-bsp/u-boot/u-boot_2016.01.bb
+++ b/recipes-bsp/u-boot/u-boot_2016.01.bb
@@ -1,0 +1,45 @@
+DESCRIPTION="Upstream's U-boot configured for sunxi devices"
+
+require recipes-bsp/u-boot/u-boot.inc
+
+DEPENDS += "dtc-native"
+
+LICENSE = "GPLv2"
+
+LIC_FILES_CHKSUM = "\
+file://Licenses/Exceptions;md5=338a7cb1e52d0d1951f83e15319a3fe7 \
+file://Licenses/bsd-2-clause.txt;md5=6a31f076f5773aabd8ff86191ad6fdd5 \
+file://Licenses/bsd-3-clause.txt;md5=4a1190eac56a9db675d58ebe86eaf50c \
+file://Licenses/eCos-2.0.txt;md5=b338cb12196b5175acd3aa63b0a0805c \
+file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+file://Licenses/ibm-pibs.txt;md5=c49502a55e35e0a8a1dc271d944d6dba \
+file://Licenses/isc.txt;md5=ec65f921308235311f34b79d844587eb \
+file://Licenses/lgpl-2.0.txt;md5=5f30f0716dfdd0d91eb439ebec522ec2 \
+file://Licenses/lgpl-2.1.txt;md5=4fbd65380cdd255951079008b364516c \
+file://Licenses/x11.txt;md5=b46f176c847b8742db02126fb8af92e2 \
+"
+
+COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i)"
+
+DEFAULT_PREFERENCE_sun4i="1"
+DEFAULT_PREFERENCE_sun5i="1"
+DEFAULT_PREFERENCE_sun7i="1"
+DEFAULT_PREFERENCE_sun8i="1"
+
+SRC_URI += "file://boot.cmd \
+"
+
+SRCREV = "fa85e826c16b9ce1ad302a57e9c4b24db0d8b930"
+
+PV = "v2016.01${SRCPV}"
+
+PE = "1"
+
+SPL_BINARY="u-boot-sunxi-with-spl.bin"
+
+UBOOT_ENV_SUFFIX = "scr"
+UBOOT_ENV = "boot"
+
+do_compile_append() {
+    ${S}/tools/mkimage -C none -A arm -T script -d ${WORKDIR}/boot.cmd ${WORKDIR}/${UBOOT_ENV_BINARY}
+}

--- a/recipes-bsp/u-boot/u-boot_2016.01.bb
+++ b/recipes-bsp/u-boot/u-boot_2016.01.bb
@@ -27,6 +27,7 @@ DEFAULT_PREFERENCE_sun7i="1"
 DEFAULT_PREFERENCE_sun8i="1"
 
 SRC_URI += "file://boot.cmd \
+	    file://orangepiplus-old-sunxi-kernel-compat.patch \
 "
 
 SRCREV = "fa85e826c16b9ce1ad302a57e9c4b24db0d8b930"

--- a/recipes-graphics/libgles/sunxi-mali_git.bb
+++ b/recipes-graphics/libgles/sunxi-mali_git.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "libGLES for the A10/A13 Allwinner processor with Mali 400 (X11)"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://README;md5=1b81a178e80ee888ee4571772699ab2c"
 
-COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
+COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i)"
 
 # These libraries shouldn't get installed in world builds unless something
 # explicitly depends upon them.

--- a/recipes-kernel/linux/linux-sunxi-h3_3.4.bb
+++ b/recipes-kernel/linux/linux-sunxi-h3_3.4.bb
@@ -1,0 +1,22 @@
+inherit kernel
+require recipes-kernel/linux/linux-yocto.inc
+
+SRC_URI = "git://github.com/ssvb/linux-sunxi.git;branch=20151207-embedded-lima-memtester-h3;protocol=http;nocheckout=1;name=machine"
+
+LINUX_VERSION ?= "3.4.39"
+LINUX_VERSION_EXTENSION_append = "-lichee"
+
+SRCREV_machine = "589da2af30717333bf9a287dcb467a07e18c1472"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+COMPATIBLE_MACHINE = "sun8i"
+
+# work around issue with binary objects in source tree
+do_compile_prepend() {
+  rm -rf ${B}/drivers/media/video/sunxi-vfe/lib
+  mkdir -p ${B}/drivers/media/video/sunxi-vfe/lib
+  ln -s ${S}/drivers/media/video/sunxi-vfe/lib/lib* ${B}/drivers/media/video/sunxi-vfe/lib/
+}
+
+KMACHINE ?= "${MACHINE}"


### PR DESCRIPTION
This is the base for H3-based boards, in which one could probably plug a clean machine definition for Orange Pi PC (but which I cannot test yet).
The Orange Pi Plus support builds on top of it, but waits for patches in board-fex and in the kernel.
