### PR TITLE
Fix for Olimex A13 SOM

### DIFF
--- a/conf/machine/olinuxino-a13som.conf
+++ b/conf/machine/olinuxino-a13som.conf
@@ -5,5 +5,6 @@
 
 require conf/machine/include/sun5i.inc
 
-UBOOT_MACHINE = "OLIMEX-A13-SOM_config"
-SUNXI_FEX_FILE = "sys_config/a13/olimex_a13_som.fex"
+KERNEL_DEVICETREE = "sun5i-a13-olinuxino-micro.dtb"
+UBOOT_MACHINE = "A13-OLinuXinoM_defconfig"
+SUNXI_FEX_FILE = "sys_config/a13/a13-olinuxinom.fex"


### PR DESCRIPTION
Missing kernel device tree definition added.
U-Boot definiton fixed to used corrected defconfig file.