### PR TITLE
sdcard_image-sunxi.bbclass: remove redundant IMAGEDATESTAMP

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -42,9 +42,6 @@ rootfs[depends] += "virtual/kernel:do_deploy"
 # SD card image name
 SDIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.sunxi-sdimg"
 
-IMAGEDATESTAMP = "${@time.strftime('%Y.%m.%d',time.gmtime())}"
-IMAGE_CMD_sunxi-sdimg[vardepsexclude] += "IMAGEDATESTAMP"
-
 IMAGE_CMD_sunxi-sdimg () {
 
 	# Align partitions
@@ -96,8 +93,8 @@ IMAGE_CMD_sunxi-sdimg () {
 
 
 	# Add stamp file
-	echo "${IMAGE_NAME}-${IMAGEDATESTAMP}" > ${WORKDIR}/image-version-info
-	mcopy -i ${WORKDIR}/boot.img -v ${WORKDIR}//image-version-info ::
+	echo "${IMAGE_NAME}" > ${WORKDIR}/image-version-info
+	mcopy -i ${WORKDIR}/boot.img -v ${WORKDIR}/image-version-info ::
 
 	# Burn Partitions
 	dd if=${WORKDIR}/boot.img of=${SDIMG} conv=notrunc seek=1 bs=$(expr ${IMAGE_ROOTFS_ALIGNMENT} \* 1024) && sync && sync


### PR DESCRIPTION
The IMAGE_NAME variable already contains the date and time so it is
redundant to also include the date again with IMAGEDATESTAMP
when writing to image-version-info in the boot partition.

Signed-off-by: Jonathan Liu <net147@gmail.com>