### PR TITLE
u-boot_2016.09.01: fix build with new upstream u-boot.inc

### DIFF
--- a/recipes-bsp/u-boot/u-boot_2016.09.01.bb
+++ b/recipes-bsp/u-boot/u-boot_2016.09.01.bb
@@ -34,6 +34,8 @@ PV = "v2016.09.01+git${SRCPV}"
 
 PE = "2"
 
+S = "${WORKDIR}/git"
+
 SPL_BINARY="u-boot-sunxi-with-spl.bin"
 
 UBOOT_ENV_SUFFIX = "scr"


### PR DESCRIPTION
Commit b36056af20e981433f143556d511dec5644930fc in oe-core master
(matching commit in poky master is a40f5d34065129ab19a3c981cbb38f854e9ae0ec)
moved some bits out of u-boot.inc (from oe-core) into u-boot-common_${PV}.inc. This
breaks many u-boot recipes in the wild, including u-boot_2016.09.01 from this layer
since the variable S itself results undefined.

Explicitly setting S fixes the issue.