### PR TITLE
Fix Olimex A20 SOM configuration

### DIFF
--- a/conf/machine/olinuxino-a20som.conf
+++ b/conf/machine/olinuxino-a20som.conf
@@ -5,5 +5,6 @@
 
 require conf/machine/include/sun7i.inc
 
-UBOOT_MACHINE = "Olimex_A20-SOM_config"
+KERNEL_DEVICETREE = "sun7i-a20-olimex-som-evb.dtb"
+UBOOT_MACHINE = "A20-Olimex-SOM-EVB_config"
 SUNXI_FEX_FILE = "sys_config/a20/olimex_a20_som.fex"


### PR DESCRIPTION
* Added missing kernel device tree definition.
* Updated U-Boot definiton.