### PR TITLE
Add support for Orange Pi One board

### DIFF
--- a/conf/machine/include/sun8i.inc
+++ b/conf/machine/include/sun8i.inc
@@ -1,0 +1,5 @@
+require conf/machine/include/sunxi.inc
+require conf/machine/include/sunxi-mali.inc
+require conf/machine/include/tune-cortexa7.inc
+
+SOC_FAMILY = "sun8i"

--- a/conf/machine/orange-pi-one.conf
+++ b/conf/machine/orange-pi-one.conf
@@ -1,0 +1,13 @@
+#@TYPE: Machine
+#@NAME: orange-pi-one
+#@DESCRIPTION: Machine configuration for the orange-pi-one, base on allwinner H3 CPU
+
+require conf/machine/include/sun8i.inc
+
+PREFERRED_VERSION_linux = "4.9.0+git%"
+PREFERRED_VERSION_u-boot = "v2016.11%"
+
+KERNEL_DEVICETREE = "sun8i-h3-orangepi-one.dtb"
+UBOOT_MACHINE = "orangepi_one_defconfig"
+
+DEFAULTTUNE = "cortexa7hf-neon-vfpv4"

--- a/conf/machine/pcduino.conf
+++ b/conf/machine/pcduino.conf
@@ -4,6 +4,9 @@
 
 require conf/machine/include/sun4i.inc
 
+PREFERRED_VERSION_linux = "4.9.0+git%"
+PREFERRED_VERSION_u-boot = "v2016.11%"
+
 KERNEL_DEVICETREE = "sun4i-a10-pcduino.dtb"
 UBOOT_MACHINE = "Linksprite_pcDuino_defconfig"
 SUNXI_FEX_FILE = "sys_config/a10/pcduino.fex"

--- a/recipes-bsp/u-boot/u-boot_2016.11.bb
+++ b/recipes-bsp/u-boot/u-boot_2016.11.bb
@@ -19,11 +19,12 @@ file://Licenses/lgpl-2.1.txt;md5=4fbd65380cdd255951079008b364516c \
 file://Licenses/x11.txt;md5=b46f176c847b8742db02126fb8af92e2 \
 "
 
-COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
+COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i)"
 
 DEFAULT_PREFERENCE_sun4i="1"
 DEFAULT_PREFERENCE_sun5i="1"
 DEFAULT_PREFERENCE_sun7i="1"
+DEFAULT_PREFERENCE_sun8i="1"
 
 SRC_URI = "git://git.denx.de/u-boot.git;branch=master \
            file://boot.cmd"

--- a/recipes-graphics/libgles/sunxi-mali_git.bb
+++ b/recipes-graphics/libgles/sunxi-mali_git.bb
@@ -91,6 +91,7 @@ do_install() {
 PACKAGES =+ "${PN}-test"
 
 RPROVIDES_${PN} += "libGLESv2.so libEGL.so libGLESv2.so libGLESv1_CM.so libMali.so"
+RDEPENDS_${PN}-test = "${PN}"
 
 FILES_${PN} += "${libdir}/lib*.so"
 FILES_${PN}-dev = "${includedir} ${libdir}/pkgconfig/*"
@@ -98,3 +99,4 @@ FILES_${PN}-test = "${bindir}/sunximali-test"
 
 # These are closed binaries generated elsewhere so don't check ldflags & text relocations
 INSANE_SKIP_${PN} = "dev-so ldflags textrel"
+INSANE_SKIP_${PN}-test = "dev-so ldflags textrel"

--- a/recipes-graphics/libgles/sunxi-mali_git.bb
+++ b/recipes-graphics/libgles/sunxi-mali_git.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "libGLES for the A10/A13 Allwinner processor with Mali 400 (X11)"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://README;md5=1b81a178e80ee888ee4571772699ab2c"
 
-COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
+COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i)"
 
 # These libraries shouldn't get installed in world builds unless something
 # explicitly depends upon them.

--- a/recipes-kernel/linux/linux_git.bb
+++ b/recipes-kernel/linux/linux_git.bb
@@ -18,9 +18,9 @@ DEFAULT_PREFERENCE = "-1"
 
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 	
-# 4.7 rc4
-PV = "4.6+4.7rc4.git${SRCPV}"
-SRCREV_pn-${PN} = "33688abb2802ff3a230bd2441f765477b94cc89e"
+# 4.9.0
+PV = "4.9.0+git${SRCPV}"
+SRCREV_pn-${PN} = "69973b830859bc6529a7a0468ba0d80ee5117826"
 
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=git;branch=master \
         file://defconfig \

--- a/recipes-kernel/linux/linux_git.bb
+++ b/recipes-kernel/linux/linux_git.bb
@@ -2,7 +2,7 @@ SECTION = "kernel"
 DESCRIPTION = "Mainline Linux kernel"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
-COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
+COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i)"
 
 inherit kernel
 


### PR DESCRIPTION
This patch set implements the following pieces:
- add support for Orange Pi One board
- bump PV for Linux git revision
- minor fixes for sunxi-mali-test package