### PR TITLE
Copy a splash.bmp splash screen for u-boot to the SD card VFAT partit…

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -90,6 +90,10 @@ IMAGE_CMD_sunxi-sdimg () {
 	then
 		mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/boot.scr ::boot.scr
 	fi
+        if [ -e "${DEPLOY_DIR_IMAGE}/splash.bmp" ]
+        then
+                mcopy -i ${WORKDIR}/boot.img -s ${DEPLOY_DIR_IMAGE}/splash.bmp ::splash.bmp
+        fi
 
 
 	# Add stamp file


### PR DESCRIPTION
Hello!

I'm working on a project where I need to put a splash screen for u-boot as a .bmp file in the VFAT partition of the SD card. This change checks for a splash.bmp file in the deploy directory and copies it in the VFAT image if one is found. There is no change in behaviour if no such file exists, so I hope you can merge this.

Regards,
Rado