### PR TITLE
Bump git kernel version

### DIFF
--- a/recipes-kernel/linux/linux_git.bb
+++ b/recipes-kernel/linux/linux_git.bb
@@ -18,9 +18,9 @@ DEFAULT_PREFERENCE = "-1"
 
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 	
-# 4.11.0-rc5
+# 4.11.0
 PV = "4.11.0+git${SRCPV}"
-SRCREV_pn-${PN} = "81d4bab4ce87228c37ab14a885438544af5c9ce6"
+SRCREV_pn-${PN} = "a351e9b9fc24e982ec2f0e76379a49826036da12"
 
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=git;branch=master \
         file://defconfig \


### PR DESCRIPTION
Bump kernel git version: use release v4.11

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>