### PR TITLE
u-boot: update support for OLinuXino Lime2 eMMC

### DIFF
--- a/recipes-bsp/u-boot/files/U-Boot-PATCHv4-1-2-ARM-dts-sunxi-Change-node-name-for-pwrseq-pin-on-Olinuxino-lime2-emmc.patch
+++ b/recipes-bsp/u-boot/files/U-Boot-PATCHv4-1-2-ARM-dts-sunxi-Change-node-name-for-pwrseq-pin-on-Olinuxino-lime2-emmc.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm/dts/sun7i-a20-olinuxino-lime2-emmc.dts b/arch/arm/dts/sun7i-a20-olinuxino-lime2-emmc.dts
+index 5ea4915f6d..10d307408f 100644
+--- a/arch/arm/dts/sun7i-a20-olinuxino-lime2-emmc.dts
++++ b/arch/arm/dts/sun7i-a20-olinuxino-lime2-emmc.dts
+@@ -56,7 +56,7 @@
+ };
+ 
+ &pio {
+-	mmc2_pins_nrst: mmc2@0 {
++	mmc2_pins_nrst: mmc2-rst-pin {
+ 		allwinner,pins = "PC16";
+ 		allwinner,function = "gpio_out";
+ 		allwinner,drive = <SUN4I_PINCTRL_10_MA>;

--- a/recipes-bsp/u-boot/files/U-Boot-PATCHv4-2-2-sun7i-Add-support-for-Olimex-A20-OLinuXino-LIME2-eMMC.patch
+++ b/recipes-bsp/u-boot/files/U-Boot-PATCHv4-2-2-sun7i-Add-support-for-Olimex-A20-OLinuXino-LIME2-eMMC.patch
@@ -1,19 +1,25 @@
-From f50ee5d9684ddc237d86841fb57a0cc6daaa76e7 Mon Sep 17 00:00:00 2001
-From: Diego Rondini <diego.rondini@kynetics.com>
-Date: Thu, 13 Apr 2017 06:51:39 +0000
-Subject: [PATCH] sunxi: add A20-OLinuXino-Lime2-eMMC defconfig
-
----
- configs/A20-OLinuXino-Lime2-eMMC_defconfig | 30 ++++++++++++++++++++++++++++++
- 1 file changed, 30 insertions(+)
- create mode 100644 configs/A20-OLinuXino-Lime2-eMMC_defconfig
-
+diff --git a/board/sunxi/MAINTAINERS b/board/sunxi/MAINTAINERS
+index 1c8817375d..1d3742c744 100644
+--- a/board/sunxi/MAINTAINERS
++++ b/board/sunxi/MAINTAINERS
+@@ -89,6 +89,11 @@ M:	Iain Paton <ipaton0@gmail.com>
+ S:	Maintained
+ F:	configs/A20-OLinuXino-Lime2_defconfig
+ 
++A20-OLINUXINO-LIME2-EMMC BOARD
++M:	Olliver Schinagl <oliver@schinagl.nl>
++S:	Maintained
++F:	configs/A20-OLinuXino-Lime2-eMMC_defconfig
++
+ A33-OLINUXINO BOARD
+ M:	Stefan Mavrodiev <stefan.mavrodiev@gmail.com>
+ S:	Maintained
 diff --git a/configs/A20-OLinuXino-Lime2-eMMC_defconfig b/configs/A20-OLinuXino-Lime2-eMMC_defconfig
 new file mode 100644
-index 0000000..b7be1a2
+index 0000000000..034ae983a5
 --- /dev/null
 +++ b/configs/A20-OLinuXino-Lime2-eMMC_defconfig
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,36 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_MACH_SUN7I=y
@@ -22,9 +28,11 @@ index 0000000..b7be1a2
 +CONFIG_MMC_SUNXI_SLOT_EXTRA=2
 +CONFIG_USB0_VBUS_PIN="PC17"
 +CONFIG_USB0_VBUS_DET="PH5"
++CONFIG_I2C1_ENABLE=y
++CONFIG_SATAPWR="PC3"
 +CONFIG_DEFAULT_DEVICE_TREE="sun7i-a20-olinuxino-lime2-emmc"
++CONFIG_AHCI=y
 +# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
-+CONFIG_SYS_EXTRA_OPTIONS="SUNXI_GMAC,RGMII,AHCI,SATAPWR=SUNXI_GPC(3)"
 +CONFIG_SPL=y
 +CONFIG_SPL_I2C_SUPPORT=y
 +# CONFIG_CMD_IMLS is not set
@@ -32,9 +40,13 @@ index 0000000..b7be1a2
 +CONFIG_CMD_DFU=y
 +CONFIG_CMD_USB_MASS_STORAGE=y
 +# CONFIG_CMD_FPGA is not set
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_SPL_ISO_PARTITION is not set
++# CONFIG_SPL_PARTITION_UUIDS is not set
 +CONFIG_DFU_RAM=y
-+CONFIG_RTL8211X_PHY_FORCE_MASTER=y
 +CONFIG_ETH_DESIGNWARE=y
++CONFIG_RGMII=y
++CONFIG_SUN7I_GMAC=y
 +CONFIG_AXP_ALDO3_VOLT=2800
 +CONFIG_AXP_ALDO4_VOLT=2800
 +CONFIG_USB_EHCI_HCD=y
@@ -44,6 +56,3 @@ index 0000000..b7be1a2
 +CONFIG_G_DNL_MANUFACTURER="Allwinner Technology"
 +CONFIG_G_DNL_VENDOR_NUM=0x1f3a
 +CONFIG_G_DNL_PRODUCT_NUM=0x1010
--- 
-1.9.1
-

--- a/recipes-bsp/u-boot/u-boot_2017.03.bb
+++ b/recipes-bsp/u-boot/u-boot_2017.03.bb
@@ -28,7 +28,8 @@ DEFAULT_PREFERENCE_sun8i="1"
 
 SRC_URI = "git://git.denx.de/u-boot.git;branch=master \
            file://boot.cmd \
-           file://0001-sunxi-add-A20-OLinuXino-Lime2-eMMC-defconfig.patch \
+           file://U-Boot-PATCHv4-1-2-ARM-dts-sunxi-Change-node-name-for-pwrseq-pin-on-Olinuxino-lime2-emmc.patch \
+           file://U-Boot-PATCHv4-2-2-sun7i-Add-support-for-Olimex-A20-OLinuXino-LIME2-eMMC.patch \
            "
 
 SRCREV = "8537ddd769f460d7fb7a62a3dcc9669049702e51"


### PR DESCRIPTION
Update support for OLinuXino Lime2 eMMC by using patches proposed for upstream.
Patches picked from:
https://patchwork.ozlabs.org/patch/761510/
https://patchwork.ozlabs.org/patch/761512/

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>