### PR TITLE
sdcard_image-sunxi.bbclass: fix deprecated notation

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -29,10 +29,10 @@ IMAGE_ROOTFS_ALIGNMENT = "2048"
 SDIMG_ROOTFS_TYPE ?= "ext4"
 SDIMG_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.${SDIMG_ROOTFS_TYPE}"
 
-IMAGE_DEPENDS_sunxi-sdimg += " \
-			parted-native \
-			mtools-native \
-			dosfstools-native \
+do_image_sunxi_sdimg[depends] += " \
+			parted-native:do_populate_sysroot \
+			mtools-native:do_populate_sysroot \
+			dosfstools-native:do_populate_sysroot \
 			virtual/kernel:do_deploy \
 			virtual/bootloader:do_deploy \
 			"


### PR DESCRIPTION
The older "IMAGE_DEPENDS_*" notation has been deprecated in favour of the
"do_image_...[depends]" notation.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>