### PR TITLE
linux: remove linux-dtb.inc

### DIFF
--- a/recipes-kernel/linux/linux_4.4.40.bb
+++ b/recipes-kernel/linux/linux_4.4.40.bb
@@ -6,7 +6,6 @@ COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
 
 inherit kernel
 
-require recipes-kernel/linux/linux-dtb.inc
 require linux.inc
 
 # Pull in the devicetree files into the rootfs

--- a/recipes-kernel/linux/linux_4.9.20.bb
+++ b/recipes-kernel/linux/linux_4.9.20.bb
@@ -6,7 +6,6 @@ COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
 
 inherit kernel
 
-require recipes-kernel/linux/linux-dtb.inc
 require linux.inc
 
 # Pull in the devicetree files into the rootfs

--- a/recipes-kernel/linux/linux_git.bb
+++ b/recipes-kernel/linux/linux_git.bb
@@ -6,7 +6,6 @@ COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i)"
 
 inherit kernel
 
-require recipes-kernel/linux/linux-dtb.inc
 require linux.inc
 
 # Pull in the devicetree files into the rootfs


### PR DESCRIPTION
Adapt to upstream change in oe-core commit 03a00be: now Device Tree support is
automatically enabled when KERNEL_DEVICETREE is set.

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>