### PR TITLE
pypi requires a https connection

### DIFF
--- a/recipes-devtools/python/pya20_0.2.1.bb
+++ b/recipes-devtools/python/pya20_0.2.1.bb
@@ -8,7 +8,7 @@ DEPENDS = "python"
 # No GPIO mappings for other machines yet
 COMPATIBLE_MACHINE = "(olinuxino-a13|olinuxino-a10|olinuxino-a20|olinuxino-a10lime|olinuxino-a20lime|olinuxino-a20lime2|olinuxino-a13som|olinuxino-a20som)"
 
-SRC_URI = "http://pypi.python.org/packages/source/p/pyA20/pyA20-${PV}.tar.gz \
+SRC_URI = "https://pypi.python.org/packages/source/p/pyA20/pyA20-${PV}.tar.gz \
            file://setup.py.patch \
            file://mapping.h \
           "

--- a/recipes-devtools/python/pya20som_0.2.1.bb
+++ b/recipes-devtools/python/pya20som_0.2.1.bb
@@ -8,7 +8,7 @@ DEPENDS = "python"
 # No GPIO mappings for other machines yet
 COMPATIBLE_MACHINE = "olinuxino-a20som"
 
-SRC_URI = "http://pypi.python.org/packages/source/p/pyA20SOM/pyA20SOM-${PV}.tar.gz \
+SRC_URI = "https://pypi.python.org/packages/source/p/pyA20SOM/pyA20SOM-${PV}.tar.gz \
            file://setup.py.patch \
            file://mapping.h \
           "


### PR DESCRIPTION
The pypi now requires a https connection to download the files.
This PR changes the urls to https.