### PR TITLE
nanopi-neo-air: add new board

### DIFF
--- a/conf/machine/nanopi-neo-air.conf
+++ b/conf/machine/nanopi-neo-air.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: nanopi-neo-air
+#@DESCRIPTION: Machine configuration for the FriendlyARM NanoPi Neo Air, based
+# on the Allwinner H3 CPU.
+
+require conf/machine/include/sun8i.inc
+
+PREFERRED_VERSION_u-boot = "v2017.11%"
+
+KERNEL_DEVICETREE = "sun8i-h3-nanopi-neo-air.dtb"
+UBOOT_MACHINE = "nanopi_neo_air_defconfig"


### PR DESCRIPTION
We have devicetree and u-boot configs for the nanopi-neo-air, so add
them. As a basic test, this boots correctly on my nanopi-neo-air.

Signed-off-by: Martin Kelly <mkelly@xevo.com>