### PR TITLE
linux: fix kernel config fragment support

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 INC_PR = "r0"
 
 inherit kernel siteinfo
+require recipes-kernel/linux/linux-yocto.inc
 
 # Enable OABI compat for people stuck with obsolete userspace
 ARM_KEEP_OABI ?= "0"
@@ -35,7 +36,6 @@ kernel_conf_variable() {
 }
 
 do_configure_prepend() {
-    echo "" > ${B}/.config
     CONF_SED_SCRIPT=""
 
     #


### PR DESCRIPTION
Currently, using kernel config fragments is not working. If you try
adding one as documented in the Yocto Mega Manual [1], it will be
ignored.

There are two reasons for this:
- The config fragment logic is in linux-yocto, so we need to
  include/require that (this is what linux-raspberrypi does in
  meta-raspberrypi).
- We remove ${B}/.config, which undoes any config created by
  linux-yocto.

Fix this by including linux-yocto and not removing ${B}/.config. With
this patch, fragments are  working again.

[1]
http://www.yoctoproject.org/docs/2.5/mega-manual/mega-manual.html#creating-the-append-file

Signed-off-by: Martin Kelly <mkelly@xevo.com>