### PR TITLE
linux: fix kernel config fragment support

### DIFF
--- a/recipes-kernel/linux/linux-mainline_4.14.2.bb
+++ b/recipes-kernel/linux/linux-mainline_4.14.2.bb
@@ -8,6 +8,10 @@ inherit kernel
 
 require linux.inc
 
+# Since we're not using git, this doesn't make a difference, but we need to fill
+# in something or kernel-yocto.bbclass will fail.
+KBRANCH ?= "master"
+
 # Pull in the devicetree files into the rootfs
 RDEPENDS_kernel-base += "kernel-devicetree"
 

--- a/recipes-kernel/linux/linux-mainline_git.bb
+++ b/recipes-kernel/linux/linux-mainline_git.bb
@@ -8,6 +8,8 @@ inherit kernel
 
 require linux.inc
 
+KBRANCH ?= "master"
+
 # Pull in the devicetree files into the rootfs
 RDEPENDS_kernel-base += "kernel-devicetree"
 

--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 INC_PR = "r0"
 
-inherit kernel siteinfo
+inherit kernel kernel-yocto siteinfo
 
 # Enable OABI compat for people stuck with obsolete userspace
 ARM_KEEP_OABI ?= "0"
@@ -22,6 +22,8 @@ LOGO_SIZE ?= '${@base_conditional("MACHINE_GUI_CLASS", "bigscreen", "vga", "qvga
 # accordingly.
 
 LOCALVERSION ?= ""
+KCONFIG_MODE ?= "alldefconfig"
+KMACHINE ?= "${MACHINE}"
 
 #kernel_conf_variable CMDLINE "\"${CMDLINE} ${CMDLINE_DEBUG}\""
 kernel_conf_variable() {
@@ -35,7 +37,6 @@ kernel_conf_variable() {
 }
 
 do_configure_prepend() {
-    echo "" > ${B}/.config
     CONF_SED_SCRIPT=""
 
     #
@@ -110,9 +111,6 @@ do_configure_prepend() {
         kernel_conf_variable ROOT_NFS y
         kernel_conf_variable CMDLINE \"${CMDLINE_NFSROOT_USB} ${CMDLINE_DEBUG}\"
     fi
-
-    sed -e "${CONF_SED_SCRIPT}" \
-    < '${WORKDIR}/defconfig' >>'${B}/.config'
 
     yes '' | oe_runmake -C ${S} O=${B} oldconfig
 }


### PR DESCRIPTION
Currently, using kernel config fragments is not working. If you try
adding one as documented in the Yocto Mega Manual [1], it will be
ignored.

There are two reasons for this:
- The config fragment logic is in kernel-yocto.bbclass, so we need to inherit
  that (this is similar to what linux-raspberrypi does in meta-raspberrypi).
- We remove ${B}/.config, which undoes any config created by
  kernel-yocto.

Fix this by inheriting kernel-yocto and not removing ${B}/.config. With
this patch, fragments are working. Note that we also need to add a few
variables (like KERNEL_KBUILD) to make kernel-yocto happy.

[1]
http://www.yoctoproject.org/docs/2.5/mega-manual/mega-manual.html#creating-the-append-file

Signed-off-by: Martin Kelly <mkelly@xevo.com>