### PR TITLE
linux-mainline: update RDEPENDS to match kernel naming

### DIFF
--- a/recipes-kernel/linux/linux-mainline_4.14.2.bb
+++ b/recipes-kernel/linux/linux-mainline_4.14.2.bb
@@ -9,7 +9,7 @@ inherit kernel
 require linux.inc
 
 # Pull in the devicetree files into the rootfs
-RDEPENDS_kernel-base += "kernel-devicetree"
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
 
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 

--- a/recipes-kernel/linux/linux-mainline_git.bb
+++ b/recipes-kernel/linux/linux-mainline_git.bb
@@ -9,7 +9,7 @@ inherit kernel
 require linux.inc
 
 # Pull in the devicetree files into the rootfs
-RDEPENDS_kernel-base += "kernel-devicetree"
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
 
 # Default is to use stable kernel version
 # If you want to use latest git version set to "1"


### PR DESCRIPTION
The kernel-devicetree class now sets RDEPENDS_${KERNEL_PACKAGE_NAME}-base so we
needs to do the same, otherwise bitbake emits a warning. Reference change is
6c8c899 commit in oe-core.

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>