### PR TITLE
linux-mainline: update to 4.14.15

### DIFF
--- a/recipes-kernel/linux/linux-mainline_4.14.15.bb
+++ b/recipes-kernel/linux/linux-mainline_4.14.15.bb
@@ -15,8 +15,8 @@ KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 
 S = "${WORKDIR}/linux-${PV}"
 	
-SRC_URI[md5sum] = "0164a000bd7b302037de4e91dff3018b"
-SRC_URI[sha256sum] = "e92690620a4e4811c6b37b2f1b6c9b32a1dde40aa12be6527c8dc215fb27464c"
+SRC_URI[md5sum] = "e1051f6b15d6399a5de2441dd4e15537"
+SRC_URI[sha256sum] = "ffc393a0c66f80375eacd3fb177b92e5c9daa07de0dcf947e925e049352e6142"
 
 SRC_URI = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz \
         file://0001-arm64-dts-orange-pi-zero-plus2-fix-sdcard-detect.patch \


### PR DESCRIPTION
This fixes an important brcmfmac use-after-free error:
brcmfmac: change driver unbind order of the sdio function devices
commit 5c3de777bdaf48bd0cfb43097c0d0fb85056cab7 upstream.
commit 01b43f2e3cad60c626daa9b174667a202cee6987 in linux-4.14.y

Without this change, I notice this error regularly when loading the wifi
firmware on the nanopi neo air.

Signed-off-by: Martin Kelly <mkelly@xevo.com>