### PR TITLE
nanopi-neo-air: add wifi DT patch

### DIFF
--- a/recipes-kernel/linux/linux-mainline/0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch
+++ b/recipes-kernel/linux/linux-mainline/0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch
@@ -1,0 +1,66 @@
+From 4ca766a768e783ee5198f1935b7f46a5df9b4a35 Mon Sep 17 00:00:00 2001
+From: Jelle van der Waa <jelle@vdwaa.nl>
+Date: Tue, 23 Jan 2018 15:58:44 -0800
+Subject: [PATCH] ARM: dts: nanopi-neo-air: Add WiFi / eMMC
+
+Enable the WiFi (AP6212) chip and eMMC support for the NanoPi NEO Air.
+
+This patch was originally submitted by Jelle van der Waa. Martin Kelly
+modified it to compile on the latest kernel, fixed up some review
+comments from Maxime Ripard, and re-tested the patch.
+
+Cc: Maxime Ripard <maxime.ripard@free-electrons.com>
+Cc: linux-sunxi@googlegroups.com
+Cc: devicetree@vger.kernel.org
+Signed-off-by: Jelle van der Waa <jelle@vdwaa.nl>
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+Signed-off-by: Maxime Ripard <maxime.ripard@free-electrons.com>
+---
+ arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts b/arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts
+index 03ff6f8b93ff..920849092cc8 100644
+--- a/arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts
++++ b/arch/arm/boot/dts/sun8i-h3-nanopi-neo-air.dts
+@@ -72,6 +72,11 @@
+ 			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>; /* PA10 */
+ 		};
+ 	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++	};
+ };
+ 
+ &mmc0 {
+@@ -84,6 +89,25 @@
+ 	status = "okay";
+ };
+ 
++&mmc1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc1_pins_a>;
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	brcmf: bcrmf@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		interrupt-parent = <&pio>;
++		interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 / EINT10 */
++		interrupt-names = "host-wake";
++	};
++};
++
+ &uart0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart0_pins_a>;
+-- 
+2.11.0
+

--- a/recipes-kernel/linux/linux-mainline_4.14.15.bb
+++ b/recipes-kernel/linux/linux-mainline_4.14.15.bb
@@ -25,5 +25,6 @@ SRC_URI[sha256sum] = "ffc393a0c66f80375eacd3fb177b92e5c9daa07de0dcf947e925e04935
 SRC_URI = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz \
         file://0001-arm64-dts-orange-pi-zero-plus2-fix-sdcard-detect.patch \
         file://0002-arm64-dts-orange-pi-zero-plus2-enable-AP6212a-WiFi-B.patch \
+        file://0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch \
         file://defconfig \
         "


### PR DESCRIPTION
Backport a devicetree patch to enable wifi on the nanopi neo air.

The patch comes from here:

https://www.spinics.net/lists/arm-kernel/msg630904.html

Signed-off-by: Martin Kelly <mkelly@xevo.com>