### PR TITLE
Add the nanopi neo 2 and plus2

### DIFF
--- a/conf/machine/nanopi-neo-air.conf
+++ b/conf/machine/nanopi-neo-air.conf
@@ -5,7 +5,7 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2017.11%"
+PREFERRED_VERSION_u-boot = "v2018.03%"
 
 KERNEL_DEVICETREE = "sun8i-h3-nanopi-neo-air.dtb"
 UBOOT_MACHINE = "nanopi_neo_air_defconfig"

--- a/conf/machine/nanopi-neo-plus2.conf
+++ b/conf/machine/nanopi-neo-plus2.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: nanopi-neo-plus2
+#@DESCRIPTION: Machine configuration for the FriendlyARM NanoPi Neo Plus2, based
+# on the Allwinner H5 SoC.
+
+require conf/machine/include/sun50i.inc
+
+PREFERRED_VERSION_u-boot = "v2018.03%"
+
+KERNEL_DEVICETREE = "allwinner/sun50i-h5-nanopi-neo-plus2.dtb"
+UBOOT_MACHINE = "nanopi_neo_plus2_defconfig"

--- a/conf/machine/nanopi-neo.conf
+++ b/conf/machine/nanopi-neo.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2017.11%"
+PREFERRED_VERSION_u-boot = "v2018.03%"
 
 KERNEL_DEVICETREE = "sun8i-h3-nanopi-neo.dtb"
 UBOOT_MACHINE = "nanopi_neo_defconfig"

--- a/conf/machine/nanopi-neo2.conf
+++ b/conf/machine/nanopi-neo2.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: nanopi-neo2
+#@DESCRIPTION: Machine configuration for the FriendlyARM NanoPi Neo 2, based on
+# the Allwinner H5 SoC.
+
+require conf/machine/include/sun50i.inc
+
+PREFERRED_VERSION_u-boot = "v2018.03%"
+
+KERNEL_DEVICETREE = "allwinner/sun50i-h5-nanopi-neo2.dtb"
+UBOOT_MACHINE = "nanopi_neo2_defconfig"

--- a/conf/machine/orange-pi-one.conf
+++ b/conf/machine/orange-pi-one.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2017.11%"
+PREFERRED_VERSION_u-boot = "v2018.03%"
 
 KERNEL_DEVICETREE = "sun8i-h3-orangepi-one.dtb"
 UBOOT_MACHINE = "orangepi_one_defconfig"

--- a/conf/machine/orange-pi-pc.conf
+++ b/conf/machine/orange-pi-pc.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2017.11%"
+PREFERRED_VERSION_u-boot = "v2018.03%"
 
 KERNEL_DEVICETREE = "sun8i-h3-orangepi-pc.dtb"
 UBOOT_MACHINE = "orangepi_pc_defconfig"

--- a/conf/machine/orange-pi-zero-plus2.conf
+++ b/conf/machine/orange-pi-zero-plus2.conf
@@ -5,7 +5,7 @@
 
 require conf/machine/include/sun50i.inc
 
-PREFERRED_VERSION_u-boot = "v2017.11%"
+PREFERRED_VERSION_u-boot = "v2018.03%"
 
 KERNEL_DEVICETREE = "allwinner/sun50i-h5-orangepi-zero-plus2.dtb"
 UBOOT_MACHINE = "orangepi_zero_plus2_defconfig"

--- a/conf/machine/orange-pi-zero.conf
+++ b/conf/machine/orange-pi-zero.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2017.11%"
+PREFERRED_VERSION_u-boot = "v2018.03%"
 
 KERNEL_DEVICETREE = "sun8i-h2-plus-orangepi-zero.dtb"
 UBOOT_MACHINE = "orangepi_zero_defconfig"

--- a/conf/machine/pcduino.conf
+++ b/conf/machine/pcduino.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/sun4i.inc
 
-PREFERRED_VERSION_u-boot = "v2017.11%"
+PREFERRED_VERSION_u-boot = "v2018.03%"
 
 KERNEL_DEVICETREE = "sun4i-a10-pcduino.dtb"
 UBOOT_MACHINE = "Linksprite_pcDuino_defconfig"

--- a/recipes-bsp/u-boot/files/u-boot-pylibfdt-native-build.patch
+++ b/recipes-bsp/u-boot/files/u-boot-pylibfdt-native-build.patch
@@ -1,12 +1,16 @@
-diff --git a/tools/Makefile b/tools/Makefile
-index 5db2a54..54bd224 100644
---- a/tools/Makefile
-+++ b/tools/Makefile
-@@ -134,6 +134,7 @@ tools/_libfdt.so: $(LIBFDT_SRCS) $(LIBFDT_SWIG)
- 	$(Q)unset CC; \
- 	unset CROSS_COMPILE; \
- 	LDFLAGS="$(HOSTLDFLAGS)" CFLAGS= VERSION="u-boot-$(UBOOTVERSION)" \
-+		CC="$(HOSTCC)" LDSHARED="$(HOSTLDSHARED)" \
- 		CPPFLAGS="$(_hostc_flags)" OBJDIR=tools \
- 		SOURCES="$(LIBFDT_SRCS) tools/libfdt.i" \
- 		SWIG_OPTS="-I$(srctree)/lib/libfdt -I$(srctree)/lib" \
+diff --git a/scripts/dtc/pylibfdt/Makefile b/scripts/dtc/pylibfdt/Makefile
+index 01d5e0ffe3..2b2dfe0bd9 100644
+--- a/scripts/dtc/pylibfdt/Makefile
++++ b/scripts/dtc/pylibfdt/Makefile
+@@ -15,6 +15,8 @@ PYLIBFDT_srcs = $(addprefix $(LIBFDT_srcdir)/,$(LIBFDT_SRCS)) \
+ 
+ quiet_cmd_pymod = PYMOD   $@
+       cmd_pymod = unset CC; unset CROSS_COMPILE; unset CFLAGS;\
++		CC="$(HOSTCC)" \
++		LDSHARED="$(HOSTLDSHARED)" \
+ 		LDFLAGS="$(HOSTLDFLAGS)" \
+ 		VERSION="u-boot-$(UBOOTVERSION)" \
+ 		CPPFLAGS="$(HOSTCFLAGS) -I$(LIBFDT_srcdir)" OBJDIR=$(obj) \
+-- 
+2.11.0
+

--- a/recipes-bsp/u-boot/u-boot_2018.03.bb
+++ b/recipes-bsp/u-boot/u-boot_2018.03.bb
@@ -21,9 +21,9 @@ SRC_URI = "git://git.denx.de/u-boot.git;branch=master \
            file://boot.cmd \
            "
 
-SRCREV = "c253573f3e269fd9a24ee6684d87dd91106018a5"
+SRCREV = "f95ab1fb6e37f0601f397091bb011edf7a98b890"
 
-PV = "v2017.11+git${SRCPV}"
+PV = "v2018.03+git${SRCPV}"
 PE = "2"
 
 S = "${WORKDIR}/git"

--- a/recipes-kernel/linux/linux-mainline/aarch64/defconfig
+++ b/recipes-kernel/linux/linux-mainline/aarch64/defconfig
@@ -431,6 +431,11 @@ CONFIG_USB_QCOM_8X16_PHY=y
 CONFIG_USB_ULPI=y
 CONFIG_USB_GADGET=y
 CONFIG_USB_RENESAS_USBHS_UDC=m
+CONFIG_USB_MUSB_HDRC=y
+# Restrict to host mode, as it is hard-coded that way in the device tree
+# (dr_mode = "host" in the &usb_otg node)
+CONFIG_USB_MUSB_HOST=y
+CONFIG_USB_MUSB_SUNXI=y
 CONFIG_MMC=y
 CONFIG_MMC_BLOCK_MINORS=32
 CONFIG_MMC_ARMMMCI=y


### PR DESCRIPTION
This patch series enables the nanopi neo plus 2 and the neo 2. With it, I'm able to boot successfully on both boards. It requires upgrading u-boot to v2018.03 in order to new u-boot configs.