### PR TITLE
NanoPI Neo Plus2

### DIFF
--- a/conf/machine/nanopi-neo-plus2.conf
+++ b/conf/machine/nanopi-neo-plus2.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: nanopi-neo-plus2
+#@DESCRIPTION: Machine configuration for the FriendlyARM NanoPi NEO Plus2, based
+# on the Allwinner H5 CPU.
+
+require conf/machine/include/sun50i.inc
+
+PREFERRED_VERSION_u-boot = "v2018.03%"
+
+KERNEL_DEVICETREE = "allwinner/sun50i-h5-nanopi-neo-plus2.dtb"
+UBOOT_MACHINE = "nanopi_neo_plus2_defconfig"

--- a/recipes-bsp/u-boot/files/u-boot-pylibfdt-native-build.patch
+++ b/recipes-bsp/u-boot/files/u-boot-pylibfdt-native-build.patch
@@ -1,12 +1,12 @@
-diff --git a/tools/Makefile b/tools/Makefile
-index 5db2a54..54bd224 100644
---- a/tools/Makefile
-+++ b/tools/Makefile
-@@ -134,6 +134,7 @@ tools/_libfdt.so: $(LIBFDT_SRCS) $(LIBFDT_SWIG)
- 	$(Q)unset CC; \
- 	unset CROSS_COMPILE; \
- 	LDFLAGS="$(HOSTLDFLAGS)" CFLAGS= VERSION="u-boot-$(UBOOTVERSION)" \
+diff --git a/scripts/dtc/pylibfdt/Makefile b/scripts/dtc/pylibfdt/Makefile
+index 01d5e0f..78c4d72 100644
+--- a/scripts/dtc/pylibfdt/Makefile
++++ b/scripts/dtc/pylibfdt/Makefile
+@@ -15,6 +15,7 @@ PYLIBFDT_srcs = $(addprefix $(LIBFDT_srcdir)/,$(LIBFDT_SRCS)) \
+ 
+ quiet_cmd_pymod = PYMOD   $@
+       cmd_pymod = unset CC; unset CROSS_COMPILE; unset CFLAGS;\
 +		CC="$(HOSTCC)" LDSHARED="$(HOSTLDSHARED)" \
- 		CPPFLAGS="$(_hostc_flags)" OBJDIR=tools \
- 		SOURCES="$(LIBFDT_SRCS) tools/libfdt.i" \
- 		SWIG_OPTS="-I$(srctree)/lib/libfdt -I$(srctree)/lib" \
+ 		LDFLAGS="$(HOSTLDFLAGS)" \
+ 		VERSION="u-boot-$(UBOOTVERSION)" \
+ 		CPPFLAGS="$(HOSTCFLAGS) -I$(LIBFDT_srcdir)" OBJDIR=$(obj) \

--- a/recipes-bsp/u-boot/u-boot_2018.03.bb
+++ b/recipes-bsp/u-boot/u-boot_2018.03.bb
@@ -21,9 +21,9 @@ SRC_URI = "git://git.denx.de/u-boot.git;branch=master \
            file://boot.cmd \
            "
 
-SRCREV = "c253573f3e269fd9a24ee6684d87dd91106018a5"
+SRCREV = "f95ab1fb6e37f0601f397091bb011edf7a98b890"
 
-PV = "v2017.11+git${SRCPV}"
+PV = "v2018.03+git${SRCPV}"
 PE = "2"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Add support for the NanoPI Neo Plus2 board and bump u-boot to v2018.03 because it includes the device tree for the board.