### PR TITLE
RFC: fix for regression: mainline defconfig files from recipes-kernel are not used

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -111,6 +111,9 @@ do_configure_prepend() {
         kernel_conf_variable CMDLINE \"${CMDLINE_NFSROOT_USB} ${CMDLINE_DEBUG}\"
     fi
 
+    sed -e "${CONF_SED_SCRIPT}" \
+    < '${WORKDIR}/defconfig' >>'${B}/.config'
+
     yes '' | oe_runmake -C ${S} O=${B} oldconfig
 }
 


### PR DESCRIPTION
In PR#200 linux-mainline.inc has been modified to support config fragments. The following snippet has been also removed:

```
-    sed -e "${CONF_SED_SCRIPT}" \
-    < '${WORKDIR}/defconfig' >>'${B}/.config'
```
Due to this change architecture specific mainline defconfig files are not merged into the final kernel configuration. As a result, if kernel fragments are not used, we get some default ARM kernel config w/o support for Allwinner chips.

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>