### PR TITLE
orange-pi-pc-plus: update preferred U-boot version to v2018.03

### DIFF
--- a/conf/machine/orange-pi-pc-plus.conf
+++ b/conf/machine/orange-pi-pc-plus.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2017.03%"
+PREFERRED_VERSION_u-boot = "v2018.03%"
 
 KERNEL_DEVICETREE = "sun8i-h3-orangepi-pc-plus.dtb"
 UBOOT_MACHINE = "orangepi_pc_plus_defconfig"


### PR DESCRIPTION
v2017.03 no longer exists and produces warnings if set as preferred:

NOTE: Resolving any missing task queue dependencies
NOTE: preferred version v2017.03% of u-boot not available (for item virtual/bootloader)
NOTE: versions of u-boot available: 1:2018.01 2:v2018.03+gitAUTOINC+f95ab1fb6e
NOTE: preferred version v2017.03% of u-boot not available (for item u-boot-dev)
NOTE: versions of u-boot available: 1:2018.01 2:v2018.03+gitAUTOINC+f95ab1fb6e
NOTE: preferred version v2017.03% of u-boot not available (for item u-boot)
NOTE: versions of u-boot available: 1:2018.01 2:v2018.03+gitAUTOINC+f95ab1fb6e

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>