### PR TITLE
remove UBOOT_LOADADDRES 

### DIFF
--- a/conf/machine/include/sunxi.inc
+++ b/conf/machine/include/sunxi.inc
@@ -26,7 +26,6 @@ MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
 UBOOT_LOCALVERSION = "-g${@d.getVar('SRCPV', True).partition('+')[2][0:7]}"
 
 UBOOT_ENTRYPOINT ?= "0x40008000"
-UBOOT_LOADADDRESS ?= "0x400080OB00"
 
 SPL_BINARY ?= "u-boot-sunxi-with-spl.bin"
 


### PR DESCRIPTION
This has been assigned a value containing a typo since 2015, my
assumption is that this is not used and hence we can simply drop
it. The typo is that the address contains a 'O' character instead
of '0', the last one is a zero.

Either way the kernel.bbclass will set a default value, that is:

     UBOOT_LOADADDRESS ?= "${UBOOT_ENTRYPOINT}"

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>