### PR TITLE
u-boot_2018.03.bb: Enable eMMC support for Nanopi Neo Air

### DIFF
--- a/recipes-bsp/u-boot/files/0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
+++ b/recipes-bsp/u-boot/files/0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
@@ -1,0 +1,26 @@
+From f4a77da23b3890b53efab6a927cbe99b76ef3b26 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@resin.io>
+Date: Wed, 12 Sep 2018 14:22:49 +0200
+Subject: [PATCH] nanopi_neo_air_defconfig: Enable eMMC support
+
+Upstream-status: Pending
+Signed-off-by: Florin Sarbu <florin@resin.io>
+---
+ configs/nanopi_neo_air_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/nanopi_neo_air_defconfig b/configs/nanopi_neo_air_defconfig
+index ca9c2dd..74ce044 100644
+--- a/configs/nanopi_neo_air_defconfig
++++ b/configs/nanopi_neo_air_defconfig
+@@ -10,6 +10,7 @@ CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-nanopi-neo-air"
+ # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
+ CONFIG_CONSOLE_MUX=y
+ CONFIG_SPL=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+ # CONFIG_CMD_FLASH is not set
+ # CONFIG_SPL_DOS_PARTITION is not set
+ # CONFIG_SPL_ISO_PARTITION is not set
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot_2018.03.bb
+++ b/recipes-bsp/u-boot/u-boot_2018.03.bb
@@ -18,6 +18,7 @@ DEFAULT_PREFERENCE_sun50i="1"
 
 SRC_URI = "git://git.denx.de/u-boot.git;branch=master \
            file://u-boot-pylibfdt-native-build.patch \
+           file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
            file://boot.cmd \
            "
 


### PR DESCRIPTION
Signed-off-by: Florin Sarbu <florin@resin.io>