### PR TITLE
Adde orange-pi-zero wifi support

### DIFF
--- a/recipes-kernel/linux/linux-mainline/orange-pi-zero/0001-add-wifi-support.patch
+++ b/recipes-kernel/linux/linux-mainline/orange-pi-zero/0001-add-wifi-support.patch
@@ -1,0 +1,79 @@
+diff --git a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+index 6713d0f2b3f4..ad0829e8f716 100644
+--- a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
++++ b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+@@ -80,19 +80,22 @@
+ 		};
+ 	};
+ 
+-	reg_vcc_wifi: reg_vcc_wifi {
++	vdd_wifi: vdd_wifi {
+ 		compatible = "regulator-fixed";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		regulator-name = "vcc-wifi";
+-		enable-active-high;
++		regulator-name = "wifi";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
+ 		gpio = <&pio 0 20 GPIO_ACTIVE_HIGH>;
++		startup-delay-us = <70000>;
++		enable-active-high;
+ 	};
+ 
+-	wifi_pwrseq: wifi_pwrseq {
++	pwrseq_wifi: pwrseq_wifi@0 {
+ 		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_rst>;
+ 		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
+-		post-power-on-delay-ms = <200>;
++		post-power-on-delay-ms = <50>;
+ 	};
+ };
+ 
+@@ -124,9 +127,11 @@
+ &mmc1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&mmc1_pins_a>;
+-	vmmc-supply = <&reg_vcc_wifi>;
+-	mmc-pwrseq = <&wifi_pwrseq>;
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&vdd_wifi>;
++	mmc-pwrseq = <&pwrseq_wifi>;
+ 	bus-width = <4>;
++	max-frequency = <16000000>;
+ 	non-removable;
+ 	status = "okay";
+ 
+@@ -136,9 +141,30 @@
+ 	 */
+ 	xr819: sdio_wifi@1 {
+ 		reg = <1>;
++		compatible = "xradio,xr819";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_wake>;
++		interrupt-parent = <&pio>;
++		interrupts = <6 10 IRQ_TYPE_EDGE_RISING>;
++		interrupt-names = "host-wake";
++		local-mac-address = [dc 44 6d c0 ff ee];
+ 	};
+ };
+ 
++&pio {
++	wifi_wake: wifi_wake {
++		pins = "PG10";
++		function = "gpio_in";
++    };
++};
++
++&r_pio {
++	wifi_rst: wifi_rst {
++		pins = "PL7";
++		function = "gpio_out";
++    };
++};
++
+ &mmc1_pins_a {
+ 	bias-pull-up;
+ };

--- a/recipes-kernel/linux/linux-mainline_4.16.13.bb
+++ b/recipes-kernel/linux/linux-mainline_4.16.13.bb
@@ -26,3 +26,7 @@ SRC_URI = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz \
         file://0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch \
         file://defconfig \
         "
+
+SRC_URI_append_orange-pi-zero += "\
+	file://0001-add-wifi-support.patch \
+	"

--- a/recipes-kernel/xradio-firmware/xradio-firmware.bb
+++ b/recipes-kernel/xradio-firmware/xradio-firmware.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "Xradio xr819 WiFi firmware"
+LICENSE = "CC0-1.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=0ceb3372c9595f0a8067e55da801e4a1"
+
+PV = "1.0"
+PR = "r0"
+
+SRCREV = "8b4a4ed16f7f9d12e59ff2f9ceba3cc335374dbe"
+
+COMPATIBLE_MACHINE = "orange-pi-zero"
+
+SRC_URI = "git://github.com/armbian/build.git;protocol=https"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+    install -d ${D}${base_libdir}/firmware/xr819
+    install -m 0644 ${S}/bin/firmware-overlay/xr819/boot_xr819.bin ${D}${base_libdir}/firmware/xr819/
+    install -m 0644 ${S}/bin/firmware-overlay/xr819/sdd_xr819.bin ${D}${base_libdir}/firmware/xr819/
+    install -m 0644 ${S}/bin/firmware-overlay/xr819/fw_xr819.bin ${D}${base_libdir}/firmware/xr819/
+}
+
+FILES_${PN} = "${base_libdir}/*"
+
+PACKAGES = "${PN}"

--- a/recipes-kernel/xradio/xradio.bb
+++ b/recipes-kernel/xradio/xradio.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Xradio WiFi driver for orangepi-zero"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
+
+inherit module
+
+PV = "0.1"
+PR = "r0"
+
+RDEPENDS_${PN} += "xradio-firmware"
+
+COMPATIBLE_MACHINE = "orange-pi-zero"
+
+SRCREV = "d649e5a78efdc56ecd0951e35ca60db175650232"
+
+SRC_URI = "git://github.com/fifteenhex/xradio.git;protocol=https \
+           file://Add_Targets_To_Makefile.patch \
+          "
+
+S = "${WORKDIR}/git"
+
+KERNEL_MODULE_AUTOLOAD += "xradio_wlan"

--- a/recipes-kernel/xradio/xradio/Add_Targets_To_Makefile.patch
+++ b/recipes-kernel/xradio/xradio/Add_Targets_To_Makefile.patch
@@ -1,0 +1,19 @@
+diff --git a/Makefile b/Makefile
+index fd15d31..078a2ad 100644
+--- a/Makefile
++++ b/Makefile
+@@ -50,3 +50,14 @@ ccflags-y += -DXRADIO_USE_LONG_KEEP_ALIVE_PERIOD
+ ldflags-y += --strip-debug
+ 
+ obj-$(CONFIG_XRADIO) += xradio_wlan.o
++
++SRC := $(shell pwd)
++
++all:
++	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules
++
++modules_install:
++	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install
++
++clean:
++	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) clean


### PR DESCRIPTION
Took some patches from https://github.com/Halolo/orange-pi-distro.git to have wifi support for opi-zero