### PR TITLE
linux: specify explicit dependencies to configme task

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -35,6 +35,10 @@ kernel_conf_variable() {
     fi
 }
 
+do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}binutils:do_populate_sysroot"
+do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
+do_kernel_configme[depends] += "bc-native:do_populate_sysroot bison-native:do_populate_sysroot"
+
 do_configure_prepend() {
     CONF_SED_SCRIPT=""
 


### PR DESCRIPTION
This change is an adaptation of commit 81e8a52e8e40e47 from poky/master.

Linux kernel build dependencies include bison since v4.16.
There were two different commits in poky adding those dependencies:
- poky/master: 81e8a52e8e40e47
- poky/sumo:   20e4d309e12bf10

However just adding bison-native to DEPENDS in linux or linux-yocto
class (as in poky/sumo) appears to be insufficient. The reason has
been clarified in 81e8a52e8e40e47 commit message:

"For linux-yocto, we also need to specify the compiler/tools dependencies
for the configme task since it executes before configure and hence the
main kernel build DEPENDS will not always be in the sysroot before it
executes. Without those dependencies the kernel will be incorrectly
configured (i.e. bison is missing) or the configuration will fail
the mitigation tests."

Layer meta-sunxi is compatible with multiple Yocto releases. Some of
those releases have been developed and tested with earlier kernels.
So they may not include new bison kernel build dependencies. That
is why it  makes sense to specify new kernel build dependencies
explicitely in meta-sunxi kernel recipes rather than rely upon
upper layers.

Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>