### PR TITLE
Add pine64-plus machine

### DIFF
--- a/conf/machine/pine64-plus.conf
+++ b/conf/machine/pine64-plus.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: pine64-plus
+#@DESCRIPTION: Machine configuration for the pine64-plus, based on Allwinner A64 CPU
+
+
+require conf/machine/include/sun50i.inc
+
+PREFERRED_VERSION_u-boot = "v2018.09%"
+
+KERNEL_DEVICETREE = "allwinner/sun50i-a64-pine64-plus.dtb"
+UBOOT_MACHINE = "pine64_plus_defconfig"


### PR DESCRIPTION
Adds A64-based pine64-plus machine.

Signed-off-by: Matt Porter <mporter@konsulko.com>