### PR TITLE
xradio-firmware: Update git repository und paths

### DIFF
--- a/recipes-kernel/xradio-firmware/xradio-firmware.bb
+++ b/recipes-kernel/xradio-firmware/xradio-firmware.bb
@@ -5,19 +5,19 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=0ceb3372c9595f0a
 PV = "1.0"
 PR = "r0"
 
-SRCREV = "8b4a4ed16f7f9d12e59ff2f9ceba3cc335374dbe"
+SRCREV = "bddd21b7f895be9f0c37e435f0a7ac84405c6091"
 
 COMPATIBLE_MACHINE = "orange-pi-zero"
 
-SRC_URI = "git://github.com/armbian/build.git;protocol=https"
+SRC_URI = "git://github.com/armbian/firmware.git;protocol=https"
 
 S = "${WORKDIR}/git"
 
 do_install() {
     install -d ${D}${base_libdir}/firmware/xr819
-    install -m 0644 ${S}/bin/firmware-overlay/xr819/boot_xr819.bin ${D}${base_libdir}/firmware/xr819/
-    install -m 0644 ${S}/bin/firmware-overlay/xr819/sdd_xr819.bin ${D}${base_libdir}/firmware/xr819/
-    install -m 0644 ${S}/bin/firmware-overlay/xr819/fw_xr819.bin ${D}${base_libdir}/firmware/xr819/
+    install -m 0644 ${S}/xr819/boot_xr819.bin ${D}${base_libdir}/firmware/xr819/
+    install -m 0644 ${S}/xr819/sdd_xr819.bin ${D}${base_libdir}/firmware/xr819/
+    install -m 0644 ${S}/xr819/fw_xr819.bin ${D}${base_libdir}/firmware/xr819/
 }
 
 FILES_${PN} = "${base_libdir}/*"


### PR DESCRIPTION
I saw that the git repo used in the xradio-firmware recipe was outdated and updated it to the new location including the path changes, that came with it.