### PR TITLE
machine: use armv8a, not armv8

### DIFF
--- a/conf/machine/include/sun50i.inc
+++ b/conf/machine/include/sun50i.inc
@@ -1,4 +1,4 @@
 require conf/machine/include/sunxi64.inc
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/arm/arch-armv8a.inc
 
 SOC_FAMILY = "sun50i"


### PR DESCRIPTION
In the latest OE, this file has been renamed. Since this board is
ARMv8-A, we should use the armv8a config instead of the armv8 config.

Signed-off-by: Martin Kelly <mkelly@xevo.com>