### PR TITLE
sunxi-tools: add inherit pkgconfig

### DIFF
--- a/recipes-support/sunxi-tools/sunxi-tools_git.bb
+++ b/recipes-support/sunxi-tools/sunxi-tools_git.bb
@@ -10,6 +10,8 @@ DEPENDS += "libusb"
 SRC_URI = "git://github.com/linux-sunxi/sunxi-tools;protocol=git"
 SRCREV = "9a3d62aa0c820b3dd42ba3409b2043f4143683cd"
 
+inherit pkgconfig
+
 S = "${WORKDIR}/git"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
sunxi-tools requires pkg-config native binary
which may be missing wihen pkgconfig class
is not inherited.

Signed-off-by: Dariusz Pelowski <dariusz.pelowski@gmail.com>