### PR TITLE
misc: Replace dri2proto with xorgproto

### DIFF
--- a/recipes-graphics/libgles/sunxi-mali_git.bb
+++ b/recipes-graphics/libgles/sunxi-mali_git.bb
@@ -31,7 +31,7 @@ SRC_URI = "gitsm://github.com/linux-sunxi/sunxi-mali.git \
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "libdrm dri2proto libump"
+DEPENDS = "libdrm xorgproto libump"
 
 PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)}"
 PACKAGECONFIG[wayland] = "EGL_TYPE=framebuffer,,,"

--- a/recipes-graphics/xorg-xserver/libdri2_git.bb
+++ b/recipes-graphics/xorg-xserver/libdri2_git.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "Library for the DRI2 extension to the X Window System"
 LICENSE = "MIT-X"
 LIC_FILES_CHKSUM = "file://COPYING;md5=827da9afab1f727f2a66574629e0f39c"
 
-DEPENDS = "libdrm libxext xextproto libxfixes dri2proto"
+DEPENDS = "libdrm libxext libxfixes xorgproto"
 
 PE = "1"
 PV = "1.0.0+git${SRCPV}"


### PR DESCRIPTION
dri2proto and xextproto was replaced by xorgproto
see: https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#migration

Signed-off-by: Marek Belisko <marek.belisko@open-nandra.com>