### PR TITLE
Sunxi kernel bump

### DIFF
--- a/conf/machine/include/sunxi.inc
+++ b/conf/machine/include/sunxi.inc
@@ -13,6 +13,7 @@ XSERVER = "xserver-xorg \
            xf86-input-keyboard"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-mainline"
+PREFERRED_VERSION_linux-mainline ?= "4.19%"
 PREFERRED_PROVIDER_u-boot ?= "u-boot"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
 

--- a/recipes-kernel/linux/linux-mainline_4.19.46.bb
+++ b/recipes-kernel/linux/linux-mainline_4.19.46.bb
@@ -1,7 +1,7 @@
 SECTION = "kernel"
 DESCRIPTION = "Mainline Linux kernel"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i|sun50i)"
 
 inherit kernel
@@ -18,9 +18,9 @@ RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 
 S = "${WORKDIR}/linux-${PV}"
-	
-SRC_URI[md5sum] = "86f56f586f35ac3a98e086dccfd2ff99"
-SRC_URI[sha256sum] = "6f0a7b3abd48eca3df5e29bfbcfc1c06dd2792f86d23cdb9ad37cf3e572df2e3"
+
+SRC_URI[md5sum] = "5e171996b176df3db2150bcb47d042a7"
+SRC_URI[sha256sum] = "097b52fe8a872259f4a3dba571b2eaf7b9863d9cde5399c6b316dec0ef57e67a"
 
 SRC_URI = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz \
         file://0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch \

--- a/recipes-kernel/linux/linux-mainline_5.0.19.bb
+++ b/recipes-kernel/linux/linux-mainline_5.0.19.bb
@@ -1,0 +1,32 @@
+SECTION = "kernel"
+DESCRIPTION = "Mainline Linux kernel"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i|sun50i)"
+
+inherit kernel
+
+require linux.inc
+
+# Since we're not using git, this doesn't make a difference, but we need to fill
+# in something or kernel-yocto.bbclass will fail.
+KBRANCH ?= "master"
+
+# Pull in the devicetree files into the rootfs
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
+
+KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
+
+S = "${WORKDIR}/linux-${PV}"
+
+SRC_URI[md5sum] = "52fb710109527b042278359526588da8"
+SRC_URI[sha256sum] = "0bf0d5c64dafc1184e9aafd2f3ebb77aa88ddee881a7766436258feaa214d9ec"
+
+SRC_URI = "https://www.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz \
+        file://0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch \
+        file://defconfig \
+        "
+
+SRC_URI_append_orange-pi-zero += "\
+	file://0001-add-wifi-support.patch \
+	"

--- a/recipes-kernel/linux/linux-mainline_5.2-rc2.bb
+++ b/recipes-kernel/linux/linux-mainline_5.2-rc2.bb
@@ -15,17 +15,21 @@ KBRANCH ?= "master"
 # Pull in the devicetree files into the rootfs
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
 
-# Default is to use stable kernel version
-# If you want to use latest git version set to "1"
-DEFAULT_PREFERENCE = "-1"
-
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
-	
-# v4.17-rc7
-PV = "v4.17-rc7+git${SRCPV}"
-SRCREV_pn-${PN} = "b04e217704b7f879c6b91222b066983a44a7a09f"
 
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=git;branch=master \
+S = "${WORKDIR}/linux-${PV}"
+
+SRC_URI[md5sum] = "bf80c4ab5f475a2c0846340fb9eb6449"
+SRC_URI[sha256sum] = "8ec8258e75ebdcd8197328b8571435c246f55d7da7f6ed65e96aa8d4bff9a639"
+
+SRC_URI = "https://git.kernel.org/torvalds/t/linux-${PV}.tar.gz \
+        file://0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch \
         file://defconfig \
         "
-S = "${WORKDIR}/git"
+
+SRC_URI_append_orange-pi-zero += "\
+	file://0001-add-wifi-support.patch \
+	"
+
+FILES_${KERNEL_PACKAGE_NAME}-base_append = " ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo"
+


### PR DESCRIPTION
Added latest LTS (4.19 - default) + add latest stable 5.0.19 and bleeding edge 5.2-rc2
Rationale behind is to give meta-sunxi user possibility to verify latest stuff (I verified and all 3 boot frin on opi-pc-plus). Comments welcomed.