### PR TITLE
sun50i: change tuning params to cortex-a53

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,4 +14,4 @@ LAYERVERSION_meta-sunxi = "1"
 
 LAYERDEPENDS_meta-sunxi = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_meta-sunxi = "morty pyro rocko sumo thud warrior"
+LAYERSERIES_COMPAT_meta-sunxi = "warrior"

--- a/conf/machine/include/sun50i.inc
+++ b/conf/machine/include/sun50i.inc
@@ -1,4 +1,6 @@
 require conf/machine/include/sunxi64.inc
-require conf/machine/include/arm/arch-armv8a.inc
+
+DEFAULTTUNE ?= "cortexa53-crypto"
+require conf/machine/include/tune-cortexa53.inc
 
 SOC_FAMILY = "sun50i"


### PR DESCRIPTION
This changes the tuning parameters for the sun50i machines. Since the warrior release oe/poky provides a `tune-cortexa53.inc` which does what we want. Also set the default to `cortexa53-crypto` as the sun50i mcus provide a crypto engine (result not yet tested on hardware).

This will only work when using warrior, so this also removes all other releases from the `LAYERSERIES_COMPAT_meta-sunxi`.