### PR TITLE
machine: remove U-Boot PREFERRED_VERSION

### DIFF
--- a/conf/machine/nanopi-m1-plus.conf
+++ b/conf/machine/nanopi-m1-plus.conf
@@ -4,8 +4,6 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "sun8i-h3-nanopi-m1-plus.dtb"
 UBOOT_MACHINE = "nanopi_m1_plus_defconfig"
 

--- a/conf/machine/nanopi-neo-air.conf
+++ b/conf/machine/nanopi-neo-air.conf
@@ -5,7 +5,5 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "sun8i-h3-nanopi-neo-air.dtb"
 UBOOT_MACHINE = "nanopi_neo_air_defconfig"

--- a/conf/machine/nanopi-neo-plus2.conf
+++ b/conf/machine/nanopi-neo-plus2.conf
@@ -5,7 +5,5 @@
 
 require conf/machine/include/sun50i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "allwinner/sun50i-h5-nanopi-neo-plus2.dtb"
 UBOOT_MACHINE = "nanopi_neo_plus2_defconfig"

--- a/conf/machine/nanopi-neo.conf
+++ b/conf/machine/nanopi-neo.conf
@@ -4,8 +4,6 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "sun8i-h3-nanopi-neo.dtb"
 UBOOT_MACHINE = "nanopi_neo_defconfig"
 

--- a/conf/machine/nanopi-neo2.conf
+++ b/conf/machine/nanopi-neo2.conf
@@ -5,7 +5,5 @@
 
 require conf/machine/include/sun50i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "allwinner/sun50i-h5-nanopi-neo2.dtb"
 UBOOT_MACHINE = "nanopi_neo2_defconfig"

--- a/conf/machine/orange-pi-one.conf
+++ b/conf/machine/orange-pi-one.conf
@@ -4,8 +4,6 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "sun8i-h3-orangepi-one.dtb"
 UBOOT_MACHINE = "orangepi_one_defconfig"
 

--- a/conf/machine/orange-pi-pc-plus.conf
+++ b/conf/machine/orange-pi-pc-plus.conf
@@ -4,8 +4,6 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "sun8i-h3-orangepi-pc-plus.dtb"
 UBOOT_MACHINE = "orangepi_pc_plus_defconfig"
 

--- a/conf/machine/orange-pi-pc.conf
+++ b/conf/machine/orange-pi-pc.conf
@@ -4,8 +4,6 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "sun8i-h3-orangepi-pc.dtb"
 UBOOT_MACHINE = "orangepi_pc_defconfig"
 

--- a/conf/machine/orange-pi-zero-plus2.conf
+++ b/conf/machine/orange-pi-zero-plus2.conf
@@ -5,7 +5,5 @@
 
 require conf/machine/include/sun50i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "allwinner/sun50i-h5-orangepi-zero-plus2.dtb"
 UBOOT_MACHINE = "orangepi_zero_plus2_defconfig"

--- a/conf/machine/orange-pi-zero.conf
+++ b/conf/machine/orange-pi-zero.conf
@@ -4,8 +4,6 @@
 
 require conf/machine/include/sun8i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "sun8i-h2-plus-orangepi-zero.dtb"
 UBOOT_MACHINE = "orangepi_zero_defconfig"
 

--- a/conf/machine/pcduino.conf
+++ b/conf/machine/pcduino.conf
@@ -4,8 +4,6 @@
 
 require conf/machine/include/sun4i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "sun4i-a10-pcduino.dtb"
 UBOOT_MACHINE = "Linksprite_pcDuino_defconfig"
 SUNXI_FEX_FILE = "sys_config/a10/pcduino.fex"

--- a/conf/machine/pine64-plus.conf
+++ b/conf/machine/pine64-plus.conf
@@ -5,7 +5,5 @@
 
 require conf/machine/include/sun50i.inc
 
-PREFERRED_VERSION_u-boot = "v2018.09%"
-
 KERNEL_DEVICETREE = "allwinner/sun50i-a64-pine64-plus.dtb"
 UBOOT_MACHINE = "pine64_plus_defconfig"


### PR DESCRIPTION
Remove pointless U-Boot PREFERRED_VERSION, as meta-sunxi no longer
provides its own u-boot recipe.

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>