### PR TITLE
ap6212a.inc: add support for AMPAK 6212A

### DIFF
--- a/conf/machine/include/hardware/ap6212a.inc
+++ b/conf/machine/include/hardware/ap6212a.inc
@@ -1,0 +1,5 @@
+# Include for boards with AMPAK 6212A Wifi / Bluetooth module
+# https://linux-sunxi.org/Wifi#Ampak
+
+MACHINE_EXTRA_RRECOMMENDS_append = " kernel-module-brcmfmac"
+MACHINE_EXTRA_RDEPENDS_append = " linux-firmware-bcm43430"

--- a/conf/machine/nanopi-neo-plus2.conf
+++ b/conf/machine/nanopi-neo-plus2.conf
@@ -4,6 +4,7 @@
 # on the Allwinner H5 SoC.
 
 require conf/machine/include/sun50i.inc
+require conf/machine/include/hardware/ap6212a.inc
 
 KERNEL_DEVICETREE = "allwinner/sun50i-h5-nanopi-neo-plus2.dtb"
 UBOOT_MACHINE = "nanopi_neo_plus2_defconfig"

--- a/conf/machine/orange-pi-zero-plus2.conf
+++ b/conf/machine/orange-pi-zero-plus2.conf
@@ -2,8 +2,8 @@
 #@NAME: orange-pi-zero-plus2
 #@DESCRIPTION: Machine configuration for the orange-pi-zero-plus2, base on Allwinner H5 CPU
 
-
 require conf/machine/include/sun50i.inc
+require conf/machine/include/hardware/ap6212a.inc
 
 KERNEL_DEVICETREE = "allwinner/sun50i-h5-orangepi-zero-plus2.dtb"
 UBOOT_MACHINE = "orangepi_zero_plus2_defconfig"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,12 @@
+# The brcmfmac driver looks for NVRAM files using the first entry in board
+# compatible since kernel >= 5.0:
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0ad4b55b2f29784f93875e6231bf57cd233624a2
+# We create a link to the AP6212 module NVRAM file so that firmware is
+# autodetected by the driver.
+# WARNING: The following commit is required for NVRAM files to be included in
+# linux-firmware-bcm43430 package:
+# http://git.openembedded.org/openembedded-core/commit/?id=dde0f79f32fa6bab045ef60199903f74c4cc3393
+do_install_append() {
+	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.xunlong,orangepi-zero-plus2.txt
+	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.friendlyarm,nanopi-neo-plus2.txt
+}


### PR DESCRIPTION
Add support for AMPAK 6212A module with an include that:
1) installs kernel module
2) installs firmware
3) creates the required symlink with the AP6212 NVRAM file
Enable the support in the boards with the module, according to:
https://linux-sunxi.org/Table_of_Allwinner_based_boards
The link creation with compatible name works on kernels >= 5.0 and for
images including a package manager, otherwise a manual link still needs
to be created.

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>