### PR TITLE
linux-mainline: update lt to 5.4.12, rc to 5.5-rc6

### DIFF
--- a/conf/machine/include/sunxi.inc
+++ b/conf/machine/include/sunxi.inc
@@ -13,7 +13,7 @@ XSERVER = "xserver-xorg \
            xf86-input-keyboard"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-mainline"
-PREFERRED_VERSION_linux-mainline ?= "4.19%"
+PREFERRED_VERSION_linux-mainline ?= "5.4.%"
 PREFERRED_PROVIDER_u-boot ?= "u-boot"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
 

--- a/recipes-kernel/linux/linux-mainline_4.19.103.bb
+++ b/recipes-kernel/linux/linux-mainline_4.19.103.bb
@@ -1,5 +1,5 @@
 SECTION = "kernel"
-DESCRIPTION = "Mainline RC Linux kernel"
+DESCRIPTION = "Mainline Longterm Linux kernel"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i|sun50i)"
@@ -12,8 +12,6 @@ require linux.inc
 # in something or kernel-yocto.bbclass will fail.
 KBRANCH ?= "master"
 
-DEPENDS += "rsync-native"
-
 # Pull in the devicetree files into the rootfs
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
 
@@ -21,16 +19,14 @@ KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 
 S = "${WORKDIR}/linux-${PV}"
 
-SRC_URI[md5sum] = "58b2b15fb3c429948051ce4f12f30c37"
-SRC_URI[sha256sum] = "b07532aa008438e0bce2b8f0253079a4f1654a048a75ae1477c8826f32feea7a"
+SRC_URI[md5sum] = "6287e6d6658e593a2978dc718f7de3f3"
+SRC_URI[sha256sum] = "b4784571bd7f3dc10ae3dc4414876dbd73fc6750401299b206670ce3e5c4bb43"
 
-SRC_URI = "https://git.kernel.org/torvalds/t/linux-${PV}.tar.gz \
+SRC_URI = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz \
         file://0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch \
         file://defconfig \
         "
+
 SRC_URI_append_orange-pi-zero += "\
 	file://0001-dts-orange-pi-zero-Add-wifi-support.patch \
 	"
-
-FILES_${KERNEL_PACKAGE_NAME}-base_append = " ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo"
-

--- a/recipes-kernel/linux/linux-mainline_5.4.18.bb
+++ b/recipes-kernel/linux/linux-mainline_5.4.18.bb
@@ -1,5 +1,5 @@
 SECTION = "kernel"
-DESCRIPTION = "Mainline Stable Linux kernel"
+DESCRIPTION = "Mainline Longterm Linux kernel"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i|sun50i)"
@@ -21,8 +21,8 @@ KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 
 S = "${WORKDIR}/linux-${PV}"
 
-SRC_URI[md5sum] = "6f4ab59d6ac7311f4245fc359706a0b7"
-SRC_URI[sha256sum] = "78f3cfc6c20b10ff21c0bb22d7d257cab03781c44d8c5aae289f749f94f76649"
+SRC_URI[md5sum] = "dccb4d028c97b6fe5d0bca14a1afcd58"
+SRC_URI[sha256sum] = "92e9f1fd69543e9ce2a9e6eb918823b1846d2dd99246a74456263cd5ad234d89"
 
 SRC_URI = "https://www.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz \
         file://0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch \
@@ -32,3 +32,5 @@ SRC_URI = "https://www.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz \
 SRC_URI_append_orange-pi-zero += "\
 	file://0001-dts-orange-pi-zero-Add-wifi-support.patch \
 	"
+
+FILES_${KERNEL_PACKAGE_NAME}-base_append = " ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo"

--- a/recipes-kernel/linux/linux-mainline_5.5.3.bb
+++ b/recipes-kernel/linux/linux-mainline_5.5.3.bb
@@ -1,5 +1,5 @@
 SECTION = "kernel"
-DESCRIPTION = "Mainline Longterm Linux kernel"
+DESCRIPTION = "Mainline Stable Linux kernel"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i|sun50i)"
@@ -12,6 +12,8 @@ require linux.inc
 # in something or kernel-yocto.bbclass will fail.
 KBRANCH ?= "master"
 
+DEPENDS += "rsync-native"
+
 # Pull in the devicetree files into the rootfs
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
 
@@ -19,14 +21,15 @@ KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 
 S = "${WORKDIR}/linux-${PV}"
 
-SRC_URI[md5sum] = "bf96b6783a2d11178a2aaa3cf376f975"
-SRC_URI[sha256sum] = "293ec1ae0f6b3b4be83a217224b51d137f2163cf2d9d294eecf5d0a354e4e29d"
+SRC_URI[md5sum] = "3ea50025d8c679a327cf2fc225d81a46"
+SRC_URI[sha256sum] = "2bef3edcf44c746383045f4a809b2013e18c52319c827875ed8e89138951cab2"
 
-SRC_URI = "https://www.kernel.org/pub/linux/kernel/v4.x/linux-${PV}.tar.xz \
+SRC_URI = "https://www.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz \
         file://0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch \
         file://defconfig \
         "
-
 SRC_URI_append_orange-pi-zero += "\
 	file://0001-dts-orange-pi-zero-Add-wifi-support.patch \
 	"
+
+FILES_${KERNEL_PACKAGE_NAME}-base_append = " ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo"


### PR DESCRIPTION
According to:
https://www.kernel.org/category/releases.html
version 5.4 is a longterm release, so:
- update longterm to 5.4.12
- update rc to 5.5-rc6
- remove stable, as longterm is the current most recent stable
- set 5.4 as the preferred version for linux-mainline

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>