### PR TITLE
conf: machine: add orange-pi-zero-plus2-h3

### DIFF
--- a/conf/machine/orange-pi-zero-plus2-h3.conf
+++ b/conf/machine/orange-pi-zero-plus2-h3.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+#@NAME: orange-pi-zero-plus2-h3
+#@DESCRIPTION: Machine configuration for the orange-pi-zero-plus2, based on Allwinner H3 CPU
+
+require conf/machine/include/sun8i.inc
+require conf/machine/include/hardware/ap6212a.inc
+
+KERNEL_DEVICETREE = "sun8i-h3-orangepi-zero-plus2.dtb"
+UBOOT_MACHINE = "orangepi_zero_plus2_h3_defconfig"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -8,5 +8,6 @@
 # http://git.openembedded.org/openembedded-core/commit/?id=dde0f79f32fa6bab045ef60199903f74c4cc3393
 do_install_append() {
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.xunlong,orangepi-zero-plus2.txt
+	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.xunlong,orangepi-zero-plus2-h3.txt
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.friendlyarm,nanopi-neo-plus2.txt
 }


### PR DESCRIPTION
Add machine configuration for H3 variant of Orange Pi Zero Plus2.

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>