### PR TITLE
mount /boot rw from /dev/mmcblk0p1

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -13,6 +13,14 @@ inherit image_types
 #
 #
 
+# This image uses an external /boot partition, we just keep the mount point in
+# the rootfs
+rm_bootdir() {
+	rm -rf "${IMAGE_ROOTFS}/boot"
+	mkdir "${IMAGE_ROOTFS}/boot"
+}
+ROOTFS_POSTPROCESS_COMMAND += "rm_bootdir; "
+
 # This image depends on the rootfs image
 IMAGE_TYPEDEP_sunxi-sdimg = "${SDIMG_ROOTFS_TYPE}"
 

--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -1,0 +1,10 @@
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+
+# boot partition is dedicated vfat, we use sync flag to be sure new images are
+# correctly written
+/dev/mmcblk0p1       /boot                auto       defaults,sync         0  0
+

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/base-files:"


### PR DESCRIPTION
This commit is the result of a headache problem when trying to replace
the uImage file in /boot: the /boot directory content was from the
rootfs but not from the root partition, meaning that any change in this
directory would not affect the uImage used after reboot.

To fix this problem, this commit provides:

- Automatic rw mount of /dev/mmcblk0p1 on /boot
- Deletion of /boot/* files from the rootfs to just keep the mount point

The sync option has been proposed for /boot mount point in order to be
sure that kernel image override are not cached in case of power outage
to avoid partially written image.

This commit was tested on NanoPi Neo SBC.
Here is a sample output after startup:

	root@nanopi-neo:~# ls /boot
	boot.scr  image-version-info  sun8i-h3-nanopi-neo.dtb  uImage

	root@nanopi-neo:~# mount
	/dev/mmcblk0p2 on / type ext4 (rw,relatime)
	devtmpfs on /dev type devtmpfs (rw,relatime,...)
	proc on /proc type proc (rw,relatime)
	sysfs on /sys type sysfs (rw,relatime)
	tmpfs on /run type tmpfs (rw,nosuid,nodev,mode=755)
	tmpfs on /var/volatile type tmpfs (rw,relatime)
	/dev/mmcblk0p1 on /boot type vfat (rw,relatime,sync,...)
	devpts on /dev/pts type devpts (rw,relatime,...)