### PR TITLE
Revert "u-boot: rebase patch against v2020.04"

### DIFF
--- a/recipes-bsp/u-boot/files/0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
+++ b/recipes-bsp/u-boot/files/0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
@@ -1,20 +1,21 @@
-From b1e4b9672d7bdd4a6a4d08b1514b46af25996cc8 Mon Sep 17 00:00:00 2001
+From 6adb2ebdc4022c24497e9ee4dccab41d18e3105d Mon Sep 17 00:00:00 2001
 From: Florin Sarbu <florin@resin.io>
 Date: Wed, 12 Sep 2018 14:22:49 +0200
 Subject: [PATCH] nanopi_neo_air_defconfig: Enable eMMC support
 
 Upstream-status: Pending
 Signed-off-by: Florin Sarbu <florin@resin.io>
+
 ---
  configs/nanopi_neo_air_defconfig | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/configs/nanopi_neo_air_defconfig b/configs/nanopi_neo_air_defconfig
-index baaccf145e..77fa1489e4 100644
+index 5ad90ddd16..8b7a4eb45d 100644
 --- a/configs/nanopi_neo_air_defconfig
 +++ b/configs/nanopi_neo_air_defconfig
-@@ -9,3 +9,4 @@ CONFIG_CONSOLE_MUX=y
- CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-nanopi-neo-air"
+@@ -15,3 +15,4 @@ CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-nanopi-neo-air"
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
+ CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
 +CONFIG_MMC_SUNXI_SLOT_EXTRA=2


### PR DESCRIPTION
This reverts commit ebde1a411c91a81246bf325a781634b8ac3e5ada.
Dunfell uses U-Boot 2020.01, so this patch shouldn't be applied in the
dunfell branch.

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>