### PR TITLE
conf: sunxi.inc: add wks file for arm

### DIFF
--- a/conf/machine/include/sunxi.inc
+++ b/conf/machine/include/sunxi.inc
@@ -19,7 +19,7 @@ PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
 KERNEL_IMAGETYPE ?= "uImage"
 
 IMAGE_CLASSES += "sdcard_image-sunxi"
-IMAGE_FSTYPES += "ext3 tar.gz sunxi-sdimg"
+IMAGE_FSTYPES += "ext3 tar.gz sunxi-sdimg wic.gz wic.bmap"
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
 
@@ -32,3 +32,16 @@ SPL_BINARY ?= "u-boot-sunxi-with-spl.bin"
 
 SERIAL_CONSOLE ?= "115200 ttyS0"
 MACHINE_FEATURES ?= "alsa apm keyboard rtc serial screen usbgadget usbhost vfat"
+
+# Mimic the sdcard_image-sunxi.bbclass
+# image-version-info file was also generated and installed to boot partition,
+# but it is missing here - can be added somehow (how?) if required
+SUNXI_FEX_FILE ?= " "
+SUNXI_BOOT_SPACE ?= "40"
+IMAGE_BOOT_FILES ?= "${KERNEL_IMAGETYPE} boot.scr"
+# ship fex file for sunxi kernel, devicetree file for mainline kernel
+IMAGE_BOOT_FILES += "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/kernel', 'linux-sunxi', '${SUNXI_FEX_FILE}', '${KERNEL_DEVICETREE}', d)}"
+WKS_FILES ?= "sunxi-sdcard-image.wks.in"
+WKS_FILE_DEPENDS ?= "virtual/kernel u-boot"
+# in case of sunxi kernel, sunxi-board-fex must be built prior wic image assembly
+WKS_FILE_DEPENDS += " ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/kernel', 'linux-sunxi', 'sunxi-board-fex', '', d)}"

--- a/wic/sunxi-sdcard-image.wks.in
+++ b/wic/sunxi-sdcard-image.wks.in
@@ -1,0 +1,18 @@
+# short-description: Create SD card image with a boot partition
+# long-description:
+# Create an image that can be written onto a SD card using dd for use
+# with Allwinner arm (32-bit) SoC family
+#
+# The disk layout used is:
+#  - --------------------------- -------------- --------------
+# | | u-boot-sunxi-with-spl.bin |     boot     |    rootfs    |
+#  - --------------------------- -------------- --------------
+# ^ ^                           ^              ^              ^
+# | |                           |              |              |
+# 0 |                         2MiB  ${SUNXI_BOOT_SPACE}MiB  ${SUNXI_BOOT_SPACE}MiB + rootfs + IMAGE_EXTRA_SPACE
+#   8KiB 
+#
+
+part u-boot --source rawcopy --sourceparams="file=${SPL_BINARY}" --ondisk mmcblk0 --no-table --align 8
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 2048 --fixed-size ${SUNXI_BOOT_SPACE}
+part /     --source rootfs --ondisk mmcblk0 --fstype=ext4 --align 2048


### PR DESCRIPTION
Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>

Fixes: https://github.com/linux-sunxi/meta-sunxi/issues/255

Tested on the NanoPi M1

Another wks file for aarch64 would need to be added in order to fully replicate the functionality of the sunxi sdcard bbclass.