### PR TITLE
conf: machine: add bananapi-m2plus

### DIFF
--- a/conf/machine/bananapi-m2plus.conf
+++ b/conf/machine/bananapi-m2plus.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+#@NAME: bananapi-m2plus
+#@DESCRIPTION: Machine configuration for the Banana Pi M2+, base on Allwinner H3 CPU
+
+require conf/machine/include/sun8i.inc
+
+KERNEL_DEVICETREE = "sun8i-h3-bananapi-m2-plus.dtb"
+UBOOT_MACHINE = "bananapi_m2_plus_h3_defconfig"
+


### PR DESCRIPTION
Add machine configuration for H3 based Banana Pi M2+.

Signed-off-by: Marek Frydrysiak <marek.frydrysiak@gmail.com>