### PR TITLE
Fix orange-pi-zero booting with 2020.01 u-boot

### DIFF
--- a/recipes-bsp/u-boot/files/0002-Revert-sunxi-psci-avoid-error-address-of-packed-memb.patch
+++ b/recipes-bsp/u-boot/files/0002-Revert-sunxi-psci-avoid-error-address-of-packed-memb.patch
@@ -1,0 +1,67 @@
+From bb6f500c10cc8f5f31245626899e0732b7b287c5 Mon Sep 17 00:00:00 2001
+From: Marek Belisko <marek.belisko@open-nandra.com>
+Date: Wed, 19 Aug 2020 13:39:49 +0200
+Subject: [PATCH] Revert "sunxi: psci: avoid error address-of-packed-member"
+
+This reverts commit 9bd34a69a453d409792e08c00953ce8862145e65.
+---
+ arch/arm/cpu/armv7/sunxi/psci.c | 16 +++++-----------
+ 1 file changed, 5 insertions(+), 11 deletions(-)
+
+diff --git a/arch/arm/cpu/armv7/sunxi/psci.c b/arch/arm/cpu/armv7/sunxi/psci.c
+index 5b68900..2c5d99e 100644
+--- a/arch/arm/cpu/armv7/sunxi/psci.c
++++ b/arch/arm/cpu/armv7/sunxi/psci.c
+@@ -75,7 +75,7 @@ static void __secure __mdelay(u32 ms)
+ 	isb();
+ }
+ 
+-static void __secure clamp_release(void __maybe_unused *clamp)
++static void __secure clamp_release(u32 __maybe_unused *clamp)
+ {
+ #if defined(CONFIG_MACH_SUN6I) || defined(CONFIG_MACH_SUN7I) || \
+ 	defined(CONFIG_MACH_SUN8I_H3) || \
+@@ -90,7 +90,7 @@ static void __secure clamp_release(void __maybe_unused *clamp)
+ #endif
+ }
+ 
+-static void __secure clamp_set(void __maybe_unused *clamp)
++static void __secure clamp_set(u32 __maybe_unused *clamp)
+ {
+ #if defined(CONFIG_MACH_SUN6I) || defined(CONFIG_MACH_SUN7I) || \
+ 	defined(CONFIG_MACH_SUN8I_H3) || \
+@@ -99,28 +99,22 @@ static void __secure clamp_set(void __maybe_unused *clamp)
+ #endif
+ }
+ 
+-static void __secure sunxi_power_switch(void *clamp, void *pwroff_ptr, bool on,
++static void __secure sunxi_power_switch(u32 *clamp, u32 *pwroff, bool on,
+ 					int cpu)
+ {
+-	u32 pwroff;
+-
+-	memcpy(&pwroff, pwroff_ptr, sizeof(u32));
+-
+ 	if (on) {
+ 		/* Release power clamp */
+ 		clamp_release(clamp);
+ 
+ 		/* Clear power gating */
+-		clrbits_le32(&pwroff, BIT(cpu));
++		clrbits_le32(pwroff, BIT(cpu));
+ 	} else {
+ 		/* Set power gating */
+-		setbits_le32(&pwroff, BIT(cpu));
++		setbits_le32(pwroff, BIT(cpu));
+ 
+ 		/* Activate power clamp */
+ 		clamp_set(clamp);
+ 	}
+-
+-	memcpy(pwroff_ptr, &pwroff, sizeof(u32));
+ }
+ 
+ #ifdef CONFIG_MACH_SUN8I_R40
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -15,6 +15,8 @@ SRC_URI_append_sunxi = " \
            file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
            file://boot.cmd \
            "
+# fix booting issue on orange pi zero
+SRC_URI_append_orange-pi-zero = " file://0002-Revert-sunxi-psci-avoid-error-address-of-packed-memb.patch"
 
 UBOOT_ENV_SUFFIX_sunxi = "scr"
 UBOOT_ENV_sunxi = "boot"


### PR DESCRIPTION
Without this patch booting ends with Starting kernel ...

Signed-off-by: Marek Belisko <marek.belisko@open-nandra.com>