### PR TITLE
remove boot partition label

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -17,7 +17,7 @@ inherit image_types
 IMAGE_TYPEDEP_sunxi-sdimg = "${SDIMG_ROOTFS_TYPE}"
 
 # Boot partition volume id
-BOOTDD_VOLUME_ID ?= "${MACHINE}"
+BOOTDD_VOLUME_ID ?= "boot"
 
 # Boot partition size [in KiB]
 BOOT_SPACE ?= "40960"


### PR DESCRIPTION
Defaulting to the $MACHINE may lead to failure if the name was
longer than the limit of allowed volume label of fat (11 chars):

```
| Disk [...]zero-20210516083927.rootfs.sunxi-sdimg: 1011MB
| Sector size (logical/physical): 512B/512B
| Partition Table: msdos
| Disk Flags:
|
| Number  Start   End     Size    Type     File system  Flags
|  1      2097kB  44.0MB  41.9MB  primary               boot, lba
|  2      44.0MB  1009MB  965MB   primary
|
| mkfs.vfat: Label can be no longer than 11 characters
| mkfs.fat 4.2 (2021-01-31)
| WARNING: exit code 1 from a shell command.

```

I removed the label which is optional and defaults to no label. My personal feeling is that it is better to stick with the default. Otherwise the label will have to be cropped (and casted to uppercase).

Signed-off-by: Marius Kriegerowski <marius.kriegerowski@gmail.com>