### PR TITLE
Fixed Pin Assignment for Nanopi Neo Air

### DIFF
--- a/recipes-kernel/linux/linux-mainline/0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch
+++ b/recipes-kernel/linux/linux-mainline/0003-ARM-dts-nanopi-neo-air-Add-WiFi-eMMC.patch
@@ -45,7 +45,7 @@ index 03ff6f8..a9331fe 100644
  
 +&mmc1 {
 +	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc1_pins_a>;
++	pinctrl-0 = <&mmc1_pins>;
 +	vmmc-supply = <&reg_vcc3v3>;
 +	vqmmc-supply = <&reg_vcc3v3>;
 +	mmc-pwrseq = <&wifi_pwrseq>;


### PR DESCRIPTION
I'm not sure what changed, but bitbake will not compile for the Nanopi Neo Air with the current pin assignments. 

I switched from ```pinctrl-0 = <&mmc1_pins_a>;``` to ```pinctrl-0 = <&mmc1_pins>;``` and now it compiles.