### PR TITLE
delete unused UBOOT_LOADADDRESS with typo

### DIFF
--- a/conf/machine/include/sunxi64.inc
+++ b/conf/machine/include/sunxi64.inc
@@ -17,7 +17,6 @@ MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"
 UBOOT_LOCALVERSION = "-g${@d.getVar('SRCPV', True).partition('+')[2][0:7]}"
 
 UBOOT_ENTRYPOINT ?= "0x40008000"
-UBOOT_LOADADDRESS ?= "0x400080OB00"
 
 UBOOT_BINARY ?= "u-boot.itb"
 SPL_BINARY ?= "spl/sunxi-spl.bin"


### PR DESCRIPTION
according to https://github.com/linux-sunxi/meta-sunxi/pull/226 this isn't used anyway and is very confusing