### PR TITLE
layer: convert to new override syntax :boom:

### DIFF
--- a/conf/machine/include/hardware/ap6212a.inc
+++ b/conf/machine/include/hardware/ap6212a.inc
@@ -1,5 +1,5 @@
 # Include for boards with AMPAK 6212A Wifi / Bluetooth module
 # https://linux-sunxi.org/Wifi#Ampak
 
-MACHINE_EXTRA_RRECOMMENDS_append = " kernel-module-brcmfmac"
-MACHINE_EXTRA_RDEPENDS_append = " linux-firmware-bcm43430"
+MACHINE_EXTRA_RRECOMMENDS:append = " kernel-module-brcmfmac"
+MACHINE_EXTRA_RDEPENDS:append = " linux-firmware-bcm43430"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,29 +1,29 @@
-FILESEXTRAPATHS_prepend_sunxi := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:sunxi := "${THISDIR}/files:"
 
-DEPENDS_append_sunxi = " bc-native dtc-native swig-native python3-native flex-native bison-native "
-DEPENDS_append_sun50i = " atf-sunxi "
+DEPENDS:append:sunxi = " bc-native dtc-native swig-native python3-native flex-native bison-native "
+DEPENDS:append:sun50i = " atf-sunxi "
 
-COMPATIBLE_MACHINE_sunxi = "(sun4i|sun5i|sun7i|sun8i|sun50i)"
+COMPATIBLE_MACHINE:sunxi = "(sun4i|sun5i|sun7i|sun8i|sun50i)"
 
-DEFAULT_PREFERENCE_sun4i="1"
-DEFAULT_PREFERENCE_sun5i="1"
-DEFAULT_PREFERENCE_sun7i="1"
-DEFAULT_PREFERENCE_sun8i="1"
-DEFAULT_PREFERENCE_sun50i="1"
+DEFAULT_PREFERENCE:sun4i = "1"
+DEFAULT_PREFERENCE:sun5i = "1"
+DEFAULT_PREFERENCE:sun7i = "1"
+DEFAULT_PREFERENCE:sun8i = "1"
+DEFAULT_PREFERENCE:sun50i = "1"
 
-SRC_URI_append_sunxi = " \
+SRC_URI:append:sunxi = " \
            file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
            file://boot.cmd \
            "
 
-UBOOT_ENV_SUFFIX_sunxi = "scr"
-UBOOT_ENV_sunxi = "boot"
+UBOOT_ENV_SUFFIX:sunxi = "scr"
+UBOOT_ENV:sunxi = "boot"
 
-EXTRA_OEMAKE_append_sunxi = ' HOSTLDSHARED="${BUILD_CC} -shared ${BUILD_LDFLAGS} ${BUILD_CFLAGS}" '
-EXTRA_OEMAKE_append_sun50i = " BL31=${DEPLOY_DIR_IMAGE}/bl31.bin "
+EXTRA_OEMAKE:append:sunxi = ' HOSTLDSHARED="${BUILD_CC} -shared ${BUILD_LDFLAGS} ${BUILD_CFLAGS}" '
+EXTRA_OEMAKE:append:sun50i = " BL31=${DEPLOY_DIR_IMAGE}/bl31.bin "
 
 do_compile_sun50i[depends] += "atf-sunxi:do_deploy"
 
-do_compile_append_sunxi() {
+do_compile:append:sunxi() {
     ${B}/tools/mkimage -C none -A arm -T script -d ${WORKDIR}/boot.cmd ${WORKDIR}/${UBOOT_ENV_BINARY}
 }

--- a/recipes-devtools/python/pya20_0.2.12.bb
+++ b/recipes-devtools/python/pya20_0.2.12.bb
@@ -15,7 +15,7 @@ S = "${WORKDIR}/pyA20-${PV}"
 
 inherit distutils3
 
-do_compile_prepend() { 
+do_compile:prepend() { 
 cp ${WORKDIR}/mapping.h ${S}/pyA20/gpio/mapping.h
 }
 

--- a/recipes-graphics/libgles/sunxi-mali_git.bb
+++ b/recipes-graphics/libgles/sunxi-mali_git.bb
@@ -21,7 +21,7 @@ python __anonymous() {
         raise bb.parse.SkipPackage("%s-%s ONLY supports hardfp mode for now" % (pkgn, pkgv))
 }
 
-SRCREV_pn-${PN} = "d343311efc8db166d8371b28494f0f27b6a58724"
+SRCREV = "d343311efc8db166d8371b28494f0f27b6a58724"
 SRC_URI = "gitsm://github.com/linux-sunxi/sunxi-mali.git \
            file://0001-Add-EGLSyncKHR-EGLTimeKHR-and-GLChar-definition.patch \
            file://0002-Add-missing-GLchar-definition.patch \
@@ -92,13 +92,13 @@ do_install() {
 # Packages like xf86-video-fbturbo dlopen() libUMP.so, so we do need to ship the .so files in ${PN}
 PACKAGES =+ "${PN}-test"
 
-RPROVIDES_${PN} += "libGLESv2.so libEGL.so libGLESv2.so libGLESv1_CM.so libMali.so"
-RDEPENDS_${PN}-test = "${PN}"
+RPROVIDES:${PN} += "libGLESv2.so libEGL.so libGLESv2.so libGLESv1_CM.so libMali.so"
+RDEPENDS:${PN}-test = "${PN}"
 
-FILES_${PN} += "${libdir}/lib*.so"
-FILES_${PN}-dev = "${includedir} ${libdir}/pkgconfig/*"
-FILES_${PN}-test = "${bindir}/sunximali-test"
+FILES:${PN} += "${libdir}/lib*.so"
+FILES:${PN}-dev = "${includedir} ${libdir}/pkgconfig/*"
+FILES:${PN}-test = "${bindir}/sunximali-test"
 
 # These are closed binaries generated elsewhere so don't check ldflags & text relocations
-INSANE_SKIP_${PN} = "dev-so ldflags textrel"
-INSANE_SKIP_${PN}-test = "dev-so ldflags textrel"
+INSANE_SKIP:${PN} = "dev-so ldflags textrel"
+INSANE_SKIP:${PN}-test = "dev-so ldflags textrel"

--- a/recipes-graphics/libump/libump_git.bb
+++ b/recipes-graphics/libump/libump_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://debian/copyright;md5=edf7fb6071cae7ec80d537a05ee17198
 inherit autotools
 
 PV = "r4p0-00rel0+git${SRCPV}"
-SRCREV_pn-${PN} = "ec0680628744f30b8fac35e41a7bd8e23e59c39f"
+SRCREV = "ec0680628744f30b8fac35e41a7bd8e23e59c39f"
 
 SRC_URI = "git://github.com/linux-sunxi/libump.git"
 

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,5 +1,5 @@
 # Enable lima and panfrost Mesa drivers
-PACKAGECONFIG_append_use-mailine-graphics = " lima panfrost"
+PACKAGECONFIG:append:use-mailine-graphics = " lima panfrost"
 # Enable KMS renderonly Mesa support
 # See https://cgit.freedesktop.org/mesa/mesa/commit/?id=2b780fe89300199f2334539aa1678e9b68f0434f
-GALLIUMDRIVERS_append_use-mailine-graphics = ",kmsro"
+GALLIUMDRIVERS:append:use-mailine-graphics = ",kmsro"

--- a/recipes-graphics/tslib/tslib_1.1.bbappend.disabled
+++ b/recipes-graphics/tslib/tslib_1.1.bbappend.disabled
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://tslib.patch"
 

--- a/recipes-graphics/xorg-xserver/libdri2_git.bb
+++ b/recipes-graphics/xorg-xserver/libdri2_git.bb
@@ -9,7 +9,7 @@ PE = "1"
 PV = "1.0.0+git${SRCPV}"
 SRC_URI = "git://github.com/robclark/libdri2.git;protocol=http;branch=master"
 
-SRCREV_pn-${PN} = "4f1eef3183df2b270c3d5cbef07343ee5127a6a4"
+SRCREV = "4f1eef3183df2b270c3d5cbef07343ee5127a6a4"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-graphics/xorg-xserver/xf86-video-fbturbo_git.bb
+++ b/recipes-graphics/xorg-xserver/xf86-video-fbturbo_git.bb
@@ -9,7 +9,7 @@ DEPENDS += "sunxi-mali libump xorgproto"
 
 PE = "3"
 PV = "0.5.1+git${SRCPV}"
-SRCREV_pn-${PN} = "e094e3c8f9004ca3347694bd05b99d136e8621b9"
+SRCREV = "e094e3c8f9004ca3347694bd05b99d136e8621b9"
 
 SRC_URI = "git://github.com/ssvb/xf86-video-fbturbo.git;protocol=http;branch=master \
            file://20-fbturbo.conf"
@@ -18,9 +18,9 @@ S = "${WORKDIR}/git"
 
 CFLAGS += " -I${STAGING_INCDIR}/xorg "
 
-do_install_append() {
+do_install:append() {
     install -d ${D}${datadir}/X11/xorg.conf.d
     install -m 0644 ${WORKDIR}/20-fbturbo.conf ${D}${datadir}/X11/xorg.conf.d
 }
 
-FILES_${PN} += "${datadir}/X11/xorg.conf.d/20-fbturbo.conf"
+FILES:${PN} += "${datadir}/X11/xorg.conf.d/20-fbturbo.conf"

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
@@ -1,1 +1,1 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -6,7 +6,7 @@
 # WARNING: The following commit is required for NVRAM files to be included in
 # linux-firmware-bcm43430 package:
 # http://git.openembedded.org/openembedded-core/commit/?id=dde0f79f32fa6bab045ef60199903f74c4cc3393
-do_install_append() {
+do_install:append() {
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.xunlong,orangepi-zero-plus2.txt
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.xunlong,orangepi-zero-plus2-h3.txt
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.friendlyarm,nanopi-neo-plus2.txt

--- a/recipes-kernel/linux/linux-mainline.inc
+++ b/recipes-kernel/linux/linux-mainline.inc
@@ -1,5 +1,6 @@
 SECTION = "kernel"
 LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i|sun50i)"
 
 inherit kernel
@@ -25,8 +26,8 @@ SRC_URI = "https://www.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz \
 	file://defconfig \
 "
 
-SRC_URI_append_use-mailine-graphics = " file://drm.cfg"
-SRC_URI_append_bananapi = " file://axp20x.cfg"
-SRC_URI_append_cubietruck = " file://axp20x.cfg"
+SRC_URI:append:use-mailine-graphics = " file://drm.cfg"
+SRC_URI:append:bananapi = " file://axp20x.cfg"
+SRC_URI:append:cubietruck = " file://axp20x.cfg"
 
-FILES_${KERNEL_PACKAGE_NAME}-base_append = " ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo"
+FILES_${KERNEL_PACKAGE_NAME}-base:append = " ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo"

--- a/recipes-kernel/linux/linux-sunxi_3.4.bb
+++ b/recipes-kernel/linux/linux-sunxi_3.4.bb
@@ -3,13 +3,13 @@ require linux.inc
 DESCRIPTION = "Linux kernel for Allwinner a10/a20 processors"
 
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
-RDEPENDS_${PN} += "sunxi-board-fex"
+RDEPENDS:${PN} += "sunxi-board-fex"
 
 PV = "3.4.104"
 PR = "r1"
-SRCREV_pn-${PN} = "d47d367036be38c5180632ec8a3ad169a4593a88"
+SRCREV = "d47d367036be38c5180632ec8a3ad169a4593a88"
 
-MACHINE_KERNEL_PR_append = "a"
+MACHINE_KERNEL_PR:append = "a"
 
 SRC_URI += "git://github.com/linux-sunxi/linux-sunxi.git;branch=sunxi-3.4;protocol=git \
         file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \
@@ -26,7 +26,7 @@ S = "${WORKDIR}/git"
 #fix QA issue "Files/directories were installed but not shipped: /usr/src/debug"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 
-do_configure_prepend() {
+do_configure:prepend() {
     #fix arch QA issues ("Architecture did not match")
     rm -f ${S}/drivers/net/wireless/rtxx7x/tools/bin2h
     rm -f ${S}/modules/wifi/ar6302/AR6K_SDK_ISC.build_3.1_RC.329/host/lib/wac/wac

--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -39,7 +39,7 @@ do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}binutils:do_populate_sys
 do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
 do_kernel_configme[depends] += "bc-native:do_populate_sysroot bison-native:do_populate_sysroot"
 
-do_configure_prepend() {
+do_configure:prepend() {
     CONF_SED_SCRIPT=""
 
     #
@@ -118,13 +118,13 @@ do_configure_prepend() {
     yes '' | oe_runmake -C ${S} O=${B} oldconfig
 }
 
-do_configure_append() {
+do_configure:append() {
     if test -e scripts/Makefile.fwinst ; then
         sed -i -e "s:-m0644:-m 0644:g" scripts/Makefile.fwinst
     fi
 }
 
-do_install_append() {
+do_install:append() {
     oe_runmake headers_install INSTALL_HDR_PATH=${D}${exec_prefix}/src/linux-${KERNEL_VERSION} ARCH=$ARCH
 }
 

--- a/recipes-kernel/xradio-firmware/xradio-firmware.bb
+++ b/recipes-kernel/xradio-firmware/xradio-firmware.bb
@@ -20,6 +20,6 @@ do_install() {
     install -m 0644 ${S}/xr819/fw_xr819.bin ${D}${base_libdir}/firmware/xr819/
 }
 
-FILES_${PN} = "${base_libdir}/*"
+FILES:${PN} = "${base_libdir}/*"
 
 PACKAGES = "${PN}"

--- a/recipes-kernel/xradio/xradio.bb
+++ b/recipes-kernel/xradio/xradio.bb
@@ -7,7 +7,7 @@ inherit module
 PV = "0.1"
 PR = "r0"
 
-RDEPENDS_${PN} += "xradio-firmware"
+RDEPENDS:${PN} += "xradio-firmware"
 
 COMPATIBLE_MACHINE = "orange-pi-zero"
 

--- a/recipes-multimedia/gstreamer/gst-plugin-cedar_git.bb
+++ b/recipes-multimedia/gstreamer/gst-plugin-cedar_git.bb
@@ -17,7 +17,7 @@ PR = "r1"
 
 S = "${WORKDIR}/git"
 
-FILES_${PN} += "${libdir}/gstreamer-0.10/*.so"
-FILES_${PN}-dbg += "${libdir}/gstreamer-0.10/.debug"
-FILES_${PN}-dev += "${libdir}/gstreamer-0.10/*.la"
-FILES_${PN}-staticdev += "${libdir}/gstreamer-0.10/*.a"
+FILES:${PN} += "${libdir}/gstreamer-0.10/*.so"
+FILES:${PN}-dbg += "${libdir}/gstreamer-0.10/.debug"
+FILES:${PN}-dev += "${libdir}/gstreamer-0.10/*.la"
+FILES:${PN}-staticdev += "${libdir}/gstreamer-0.10/*.a"

--- a/recipes-support/sunxi-tools/sunxi-tools_git.bb
+++ b/recipes-support/sunxi-tools/sunxi-tools_git.bb
@@ -16,7 +16,7 @@ S = "${WORKDIR}/git"
 
 BBCLASSEXTEND = "native nativesdk"
 
-FILES_${PN} = "${bindir}/*"
+FILES:${PN} = "${bindir}/*"
 
 CFLAGS = "-std=c99 -D_POSIX_C_SOURCE=200112L -I./include"
 CFLAGS_class-native = "-std=c99 -D_POSIX_C_SOURCE=200112L -I./include"


### PR DESCRIPTION
OE/Yocto is migration towards new override syntax,
current master (upcomming honister release) will not
tolerate "_" as override operator.

New override syntax will be backported to
dunfell, gatesgarth, hardknott releases.

Signed-off-by: Bartłomiej Burdukiewicz <bartlomiej.burdukiewicz@gmail.com>