### PR TITLE
Minor updates

### DIFF
--- a/recipes-bsp/sunxi-board-fex/sunxi-board-fex.bb
+++ b/recipes-bsp/sunxi-board-fex/sunxi-board-fex.bb
@@ -9,9 +9,9 @@ PR = "r0"
 
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
 
-SRC_URI = "git://github.com/linux-sunxi/sunxi-boards.git;protocol=git"
+SRC_URI = "git://github.com/linux-sunxi/sunxi-boards.git;protocol=https;branch=master"
 # Increase PV with SRCREV change
-SRCREV = "496ef0fbd166cc2395daa76dd3c359357420963d"
+SRCREV = "af5f938ea14a3614d35ad3d9ab51a5d392117444"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-sunxi_3.4.bb
+++ b/recipes-kernel/linux/linux-sunxi_3.4.bb
@@ -11,7 +11,7 @@ SRCREV = "d47d367036be38c5180632ec8a3ad169a4593a88"
 
 MACHINE_KERNEL_PR:append = "a"
 
-SRC_URI += "git://github.com/linux-sunxi/linux-sunxi.git;branch=sunxi-3.4;protocol=git \
+SRC_URI += "git://github.com/linux-sunxi/linux-sunxi.git;branch=sunxi-3.4;protocol=https \
         file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \
         file://0002-use-static-inline-in-ARM-ftrace.patch \
         file://0003-gcc5-fixes.patch \


### PR DESCRIPTION
1. GitHub fetch protocol switch from "git" to "https"
2. Bump https://github.com/linux-sunxi/sunxi-boards version to the most recent "master" state