### PR TITLE
conf: machine: add orange-pi-r1

### DIFF
--- a/conf/machine/orange-pi-r1.conf
+++ b/conf/machine/orange-pi-r1.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+#@NAME: orange-pi-r1
+#@DESCRIPTION: Machine configuration for the orange-pi-r1, base on allwinner H2+ CPU
+
+require conf/machine/include/sun8i.inc
+
+KERNEL_DEVICETREE = "sun8i-h2-plus-orangepi-r1.dtb"
+UBOOT_MACHINE = "orangepi_r1_defconfig"
+


### PR DESCRIPTION
Add the machine configuration for the Orange Pi R1.

Signed-off-by: Eric Bode <eric.bode@foundries.io>