### PR TITLE
classes/sdcard_image-sunxi.bbclass: fix misplaced ":"

### DIFF
--- a/classes/sdcard_image-sunxi.bbclass
+++ b/classes/sdcard_image-sunxi.bbclass
@@ -30,7 +30,7 @@ IMAGE_ROOTFS_ALIGNMENT = "2048"
 
 SDIMG_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.${SDIMG_ROOTFS_TYPE}"
 
-do_image:sunxi_sdimg[depends] += " \
+do_image_sunxi_sdimg[depends] += " \
 			parted-native:do_populate_sysroot \
 			mtools-native:do_populate_sysroot \
 			dosfstools-native:do_populate_sysroot \


### PR DESCRIPTION
In function names, the "_" is the correct separator, and was not
replaced by ":".

Fixes mistake from commit 1f4dba30816a5f6da3dcfff8b9475bba938a01ca