### PR TITLE
libgles: sunxi-mali: fix linter warnings

### DIFF
--- a/recipes-graphics/libgles/sunxi-mali_git.bb
+++ b/recipes-graphics/libgles/sunxi-mali_git.bb
@@ -22,7 +22,7 @@ python __anonymous() {
 }
 
 SRCREV = "d343311efc8db166d8371b28494f0f27b6a58724"
-SRC_URI = "gitsm://github.com/linux-sunxi/sunxi-mali.git \
+SRC_URI = "git://github.com/linux-sunxi/sunxi-mali.git;protocol=https;branch=master \
            file://0001-Add-EGLSyncKHR-EGLTimeKHR-and-GLChar-definition.patch \
            file://0002-Add-missing-GLchar-definition.patch \
            file://0003-Fix-sed-to-replace-by-the-correct-var.patch \


### PR DESCRIPTION
fix the following linter warnings
- WARNING: sunxi-mali-git-r0 do_unpack: URL: gitsm://github.com/linux-sunxi/sunxi-mali.git uses git protocol which is no longer supported by github. Please change to ;protocol=https in the url.
- WARNING: sunxi-mali-git-r0 do_unpack: URL: gitsm://github.com/linux-sunxi/sunxi-mali.git does not set any branch parameter. The future default branch used by tools and repositories is uncertain and we will therefore soon require this is set in all git urls.