### PR TITLE
Use correct arch in sun5i.inc

### DIFF
--- a/conf/machine/include/sun5i.inc
+++ b/conf/machine/include/sun5i.inc
@@ -1,5 +1,5 @@
 require conf/machine/include/sunxi.inc
 require conf/machine/include/sunxi-mali.inc
-require conf/machine/include/arm/armv8a/tune-cortexa8.inc
+require conf/machine/include/arm/armv7a/tune-cortexa8.inc
 
 SOC_FAMILY = "sun5i"


### PR DESCRIPTION
Cortex-A8 architecture is ARMv7A. Using the wrong path was causing build failures