### PR TITLE
Banana pi zero and fix to boot stuck

### DIFF
--- a/conf/machine/bananapi-m2-zero.conf
+++ b/conf/machine/bananapi-m2-zero.conf
@@ -1,0 +1,10 @@
+#@TYPE: Machine
+#@NAME: bananapi-m2-zero
+#@DESCRIPTION: Machine configuration for the Banana Pi M2 Zero, base on Allwinner H3 CPU
+
+require conf/machine/include/sun8i.inc
+require conf/machine/include/hardware/ap6212a.inc
+
+KERNEL_DEVICETREE = "sun8i-h2-plus-bananapi-m2-zero.dtb"
+UBOOT_MACHINE = "bananapi_m2_zero_defconfig"
+

--- a/recipes-kernel/linux/linux-mainline.inc
+++ b/recipes-kernel/linux/linux-mainline.inc
@@ -28,6 +28,7 @@ SRC_URI = "https://www.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz \
 
 SRC_URI:append:use-mailine-graphics = " file://drm.cfg"
 SRC_URI:append:bananapi = " file://axp20x.cfg"
+SRC_URI:append:bananapi-m2-zero = " file://axp20x.cfg"
 SRC_URI:append:cubietruck = " file://axp20x.cfg"
 SRC_URI:append:nanopi-neo-air = " file://cam500b.cfg"
 

--- a/recipes-kernel/linux/linux-mainline.inc
+++ b/recipes-kernel/linux/linux-mainline.inc
@@ -23,6 +23,7 @@ S = "${WORKDIR}/linux-${PV}"
 SRC_URI = "https://www.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz \
 	file://0001-dts-orange-pi-zero-Add-wifi-support.patch \
 	file://0002-dts-nanopi-neo-air-add-camera.patch \
+	file://0003-dts-allwinner-bananapi-m2-zreo-Enforce-consistent-MM.patch \
 	file://defconfig \
 "
 

--- a/recipes-kernel/linux/linux-mainline/0003-dts-allwinner-bananapi-m2-zreo-Enforce-consistent-MM.patch
+++ b/recipes-kernel/linux/linux-mainline/0003-dts-allwinner-bananapi-m2-zreo-Enforce-consistent-MM.patch
@@ -1,0 +1,28 @@
+From 9b4baa9b5aab0511c46a1ae95485e1a3ea984352 Mon Sep 17 00:00:00 2001
+From: matteolel <matteolel91@hotmail.it>
+Date: Fri, 9 Dec 2022 16:38:11 +0000
+Subject: [PATCH] dts: allwinner: bananapi-m2-zreo: Enforce consistent MMC
+ numbering
+
+Enforce MMC number (sometimes the order was wrong and the device does not boot).
+---
+ arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+index 8e8634ff2..37a2ed937 100644
+--- a/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
++++ b/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+@@ -20,6 +20,9 @@ / {
+ 	aliases {
+ 		serial0 = &uart0;
+ 		serial1 = &uart1;
++		mmc0 = &mmc0;
++		mmc1 = &mmc1;
++		mmc2 = &mmc2;
+ 	};
+ 
+ 	chosen {
+-- 
+2.25.1
+


### PR DESCRIPTION
- Add a new machine for banana pi M2 zero
- Fix #354 : create alias to enforce mmc numbers