### PR TITLE
conf: machine: Add "Orange Pi One Plus" support

### DIFF
--- a/conf/machine/orange-pi-one-plus.conf
+++ b/conf/machine/orange-pi-one-plus.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+#@NAME: orange-pi-one-plus
+#@DESCRIPTION: Machine configuration for the Orange Pi One Plus, based on Allwinner H6 CPU
+
+
+require conf/machine/include/sun50i.inc
+
+KERNEL_DEVICETREE = "allwinner/sun50i-h6-orangepi-one-plus.dtb"
+UBOOT_MACHINE = "orangepi_one_plus_defconfig"


### PR DESCRIPTION
Tested on the target with image 'core-image-base'