### PR TITLE
linux-mainline: fix 'devtool modify' command fail

### DIFF
--- a/recipes-kernel/linux/linux-mainline.inc
+++ b/recipes-kernel/linux/linux-mainline.inc
@@ -18,6 +18,8 @@ RDEPENDS_${KERNEL_PACKAGE_NAME}-base += "kernel-devicetree"
 
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 
+LINUX_VERSION ?= "${PV}"
+
 S = "${WORKDIR}/linux-${PV}"
 
 SRC_URI = "https://www.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz \

--- a/recipes-kernel/linux/linux-sunxi_3.4.bb
+++ b/recipes-kernel/linux/linux-sunxi_3.4.bb
@@ -9,6 +9,8 @@ PV = "3.4.104"
 PR = "r1"
 SRCREV = "d47d367036be38c5180632ec8a3ad169a4593a88"
 
+LINUX_VERSION ?= "${PV}"
+
 MACHINE_KERNEL_PR:append = "a"
 
 SRC_URI += "git://github.com/linux-sunxi/linux-sunxi.git;branch=sunxi-3.4;protocol=https \


### PR DESCRIPTION
Traceback (most recent call last):
  File "${TOPDIR}/../src/poky/scripts/devtool", line 338, in <module>
    ret = main()
  File "${TOPDIR}/../src/poky/scripts/devtool", line 325, in main
    ret = args.func(args, config, basepath, workspace)
  File "${TOPDIR}/../src/poky/scripts/lib/devtool/standard.py", line 834, in modify
    if (os.path.exists(srcdir) and os.listdir(srcdir)) and (kernelVersion in staging_kerVer and staging_kbranch == kbranch):
TypeError: 'in <string>' requires string as left operand, not NoneType

Where 'kernelVersion' is None that cause an error.
In the code: "kernelVersion = rd.getVar('LINUX_VERSION')"
So LINUX_VERSION should be initialized

Signed-off-by: Ilja Byckevich <iljabyckevich@gmail.com>