### PR TITLE
Adhere naming convention

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,14 +4,14 @@ BBPATH .= ":${LAYERDIR}"
 # We have a recipes directory, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "meta-sunxi"
-BBFILE_PATTERN_meta-sunxi := "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-sunxi = "10"
+BBFILE_COLLECTIONS += "sunxi"
+BBFILE_PATTERN_sunxi := "^${LAYERDIR}/"
+BBFILE_PRIORITY_sunxi = "10"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERVERSION_meta-sunxi = "1"
+LAYERVERSION_sunxi = "1"
 
-LAYERDEPENDS_meta-sunxi = "core meta-python"
+LAYERDEPENDS_sunxi = "core meta-python"
 
-LAYERSERIES_COMPAT_meta-sunxi = "honister kirkstone langdale mickledore"
+LAYERSERIES_COMPAT_sunxi = "honister kirkstone langdale mickledore"


### PR DESCRIPTION
Adhere to naming convention as stated in Yocto manual section 1.3.5 Layer Configuration File.