### PR TITLE
Fix incorrect machine variable

### DIFF
--- a/conf/machine/orange-pi-zero.conf
+++ b/conf/machine/orange-pi-zero.conf
@@ -1,6 +1,6 @@
 #@TYPE: Machine
-#@NAME: orange-pi-one
-#@DESCRIPTION: Machine configuration for the orange-pi-one, base on allwinner H3 CPU
+#@NAME: orange-pi-zero
+#@DESCRIPTION: Machine configuration for the orange-pi-zero, based on Allwinner H2 CPU
 
 require conf/machine/include/sun8i.inc
 


### PR DESCRIPTION
Using the name of this machine variable resulted in an incorrect build. This commit updates the machine name to the correct format and it updates the description.