### PR TITLE
fix wic including the device tree file in IMAGE_BOOT_FILES

### DIFF
--- a/conf/machine/include/sunxi64.inc
+++ b/conf/machine/include/sunxi64.inc
@@ -45,7 +45,7 @@ do_fix_device_tree_location() {
 addtask do_fix_device_tree_location after do_write_wks_template before do_image_wic
 
 SUNXI_BOOT_SPACE ?= "40"
-IMAGE_BOOT_FILES ?= "${KERNEL_IMAGETYPE} boot.scr"
+IMAGE_BOOT_FILES ?= "${KERNEL_IMAGETYPE} boot.scr ${KERNEL_DEVICETREE}"
 
 WKS_FILES ?= "sunxi-sdcard-image.wks.in"
 WKS_FILE_DEPENDS ?= "virtual/kernel u-boot"


### PR DESCRIPTION
The change for #375 does not work as it does not include the generated dt in the boot parition. This fixes it.