### PR TITLE
Added `.conf` file for lamobo-r1 platorm

### DIFF
--- a/conf/machine/lamobo-r1.conf
+++ b/conf/machine/lamobo-r1.conf
@@ -1,0 +1,10 @@
+#@TYPE: Machine
+#@NAME: Lamobo R1
+#@DESCRIPTION: Machine configuration for the lamobo r1, based on allwinner A20 CPU http://bananapi.org/
+
+require conf/machine/include/sun7i.inc
+
+MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
+KERNEL_DEVICETREE = "sun7i-a20-lamobo-r1.dtb"
+UBOOT_MACHINE = "Lamobo_R1_config"
+SUNXI_FEX_FILE = "sys_config/a20/lamobo-r1.fex"


### PR DESCRIPTION
I have been working lately with [Lamobo R1](https://linux-sunxi.org/Lamobo_R1) platform and noticed thatthere are no `.conf` file in `meta-sunxi` repo, but devicetrees a bit deffer between `bananapi` and `lamobo-r1`. So it is better to create a config file.