### PR TITLE
add u-boot ethernet support to orange pi one plus (h6)

### DIFF
--- a/recipes-bsp/u-boot/files/0003-sunxi-H6-Enable-Ethernet-on-Orange-Pi-One-Plus.patch
+++ b/recipes-bsp/u-boot/files/0003-sunxi-H6-Enable-Ethernet-on-Orange-Pi-One-Plus.patch
@@ -1,0 +1,58 @@
+From: Anne Macedo <retpolanne@posteo.net>
+Date: Tue, 11 Jul 2023 00:39:58 +0000
+Subject: [PATCH] sunxi: H6: Enable Ethernet on Orange Pi One Plus
+
+Enable Ethernet on Orange Pi One Plus by using the correct phy for
+Realtek RTL8211E instead of the Generic One. Also use CONFIG_MACPWR to
+turn on ethernet on startup.
+
+After this patch is applied, a few issues can be seen:
+
+- there's still a PHY reset timed out error that doesn't seem to cause
+  any impacts to the overall connection
+
+- sometimes the emac driver times out after reset (yellow LED turns on
+  and never blinks)
+
+For future patches: for now, CONFIG_MACPWR is the only way to enable
+Ethernet on boot. There's already code on the dts for using the 3v3-gmac
+regulator. However, it is not probed on boot, so it only starts after a
+"regulator status" command is issued.
+
+More details about the troubleshooting on [1].
+
+Upstream-Status: Submitted
+
+[1] https://lore.kernel.org/u-boot/4wsvwgy56e2xfgtvioru2tf2ofkqprlts36qggivxogww6pn5j@4jk63zxhzhag/
+
+Signed-off-by: Anne Macedo <retpolanne@posteo.net>
+---
+ arch/arm/dts/sun50i-h6-orangepi-one-plus.dts | 2 +-
+ configs/orangepi_one_plus_defconfig          | 4 ++++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/sun50i-h6-orangepi-one-plus.dts b/arch/arm/dts/sun50i-h6-orangepi-one-plus.dts
+index 29a081e72a..6427c58f8a 100644
+--- a/arch/arm/dts/sun50i-h6-orangepi-one-plus.dts
++++ b/arch/arm/dts/sun50i-h6-orangepi-one-plus.dts
+@@ -37,7 +37,7 @@
+ 
+ &mdio {
+ 	ext_rgmii_phy: ethernet-phy@1 {
+-		compatible = "ethernet-phy-ieee802.3-c22";
++		compatible = "ethernet-phy-id001c.c915", "ethernet-phy-ieee802.3-c22" ;
+ 		reg = <1>;
+ 	};
+ };
+diff --git a/configs/orangepi_one_plus_defconfig b/configs/orangepi_one_plus_defconfig
+index aa5f540eb1..a1835492db 100644
+--- a/configs/orangepi_one_plus_defconfig
++++ b/configs/orangepi_one_plus_defconfig
+@@ -8,3 +8,7 @@ CONFIG_SUNXI_DRAM_H6_LPDDR3=y
+ # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y
++CONFIG_SUN8I_EMAC=y
++CONFIG_PHY_REALTEK=y
++CONFIG_PHY_ETHERNET_ID=y
++CONFIG_MACPWR="PD6"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -14,6 +14,7 @@ DEFAULT_PREFERENCE:sun50i = "1"
 SRC_URI:append:sunxi = " \
         file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
 	file://0002-Added-nanopi-r1-board-support.patch \
+	file://0003-sunxi-H6-Enable-Ethernet-on-Orange-Pi-One-Plus.patch \
         file://boot.cmd \
 "
 


### PR DESCRIPTION
This patch adds ethernet support to orange pi one plus. The patch has been submitted to the mailing list and is being added to the bbappend for u-boot.

Unfortunately, is doesn't keep ethernet on after kernel boot, as the kernel dts needs to be synced with the u-boot dts.

Submitted patch waiting for approval on the upstream: https://lore.kernel.org/u-boot/30debca8b31ed4d2cbd64850d48b81ac@posteo.net/T/#t