### PR TITLE
Adds LINUX_VERSION variable to linux-mainline bb

### DIFF
--- a/recipes-kernel/linux/linux-mainline_6.1.9.bb
+++ b/recipes-kernel/linux/linux-mainline_6.1.9.bb
@@ -4,6 +4,8 @@ DESCRIPTION = "Mainline Longterm Linux kernel"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
+LINUX_VERSION ?= "6.1.9"
+
 SRC_URI[sha256sum] = "d60cf185693c386e7acd9f3eb3a94ae30ffbfee0a9447a20e83711e0bdf5922b"
 
 SRC_URI:append:orange-pi-zero2  = " \

--- a/recipes-kernel/linux/linux-mainline_6.5.11.bb
+++ b/recipes-kernel/linux/linux-mainline_6.5.11.bb
@@ -2,6 +2,8 @@ require linux-mainline.inc
 
 DESCRIPTION = "Mainline Longterm Linux kernel"
 
+LINUX_VERSION ?= "6.5.11"
+
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRC_URI[sha256sum] = "2ee24af9282b80923b2da56b70aad7df2e8ee4e3f076452e05ba66be2059b519"


### PR DESCRIPTION
Fixes:

  File "/home/retpolanne/Dev/orange-pi-one-plus-image/poky/scripts/lib/devtool/standard.py", line 839, in modify
    if (os.path.exists(srcdir) and os.listdir(srcdir)) and (kernelVersion in staging_kerVer and staging_kbranch == kbranch):
                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'in <string>' requires string as left operand, not NoneType

While running `devtool modify virtual/kernel`.