### PR TITLE
Add Orange Pi Prime machine support

### DIFF
--- a/conf/machine/orange-pi-prime.conf
+++ b/conf/machine/orange-pi-prime.conf
@@ -1,0 +1,12 @@
+#@TYPE: Machine
+#@NAME: orange-pi-prime
+#@DESCRIPTION: Machine configuration for the orange-pi-prime, base on Allwinner H5 CPU
+
+require conf/machine/include/sun50i.inc
+require conf/machine/include/hardware/ap6212a.inc
+
+KERNEL_DEVICETREE = "allwinner/sun50i-h5-orangepi-prime.dtb"
+UBOOT_MACHINE = "orangepi_prime_defconfig"
+
+MACHINE_FEATURES:append = " bluetooth wifi"
+MACHINE_EXTRA_RRECOMMENDS:append = " linux-firmware-rtl8723"

--- a/recipes-kernel/linux/linux-mainline.inc
+++ b/recipes-kernel/linux/linux-mainline.inc
@@ -69,5 +69,10 @@ SRC_URI:append:bananapi = " file://axp20x.cfg"
 SRC_URI:append:bananapi-m2-zero = " file://axp20x.cfg"
 SRC_URI:append:cubietruck = " file://axp20x.cfg"
 SRC_URI:append:nanopi-neo-air = " file://cam500b.cfg"
+SRC_URI:append:orange-pi-prime = " \
+	file://0001-dts-sun50i-h5-enable-power-button-for-orange-pi-prime.patch \
+	file://0002-dts-sun50i-h5-orange-pi-prime-add-regulator.patch \
+	file://0003-dts-sun50i-h5-orange-pi-prime-add-rtl8723cs.patch \
+"
 
 FILES_${KERNEL_PACKAGE_NAME}-base:append = " ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo"

--- a/recipes-kernel/linux/linux-mainline/orange-pi-prime/0001-dts-sun50i-h5-enable-power-button-for-orange-pi-prime.patch
+++ b/recipes-kernel/linux/linux-mainline/orange-pi-prime/0001-dts-sun50i-h5-enable-power-button-for-orange-pi-prime.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Sat, 15 Jul 2023 17:06:17 +0000
+Subject: arm64: dts: sun50i: h5: enable power button for orangepi prime
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+index f430acd8558f..35e09098570f 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+@@ -63,8 +63,9 @@ gpio-keys {
+ 
+ 		key-sw4 {
+ 			label = "sw4";
+-			linux,code = <BTN_0>;
++			linux,code = <KEY_POWER>;
+ 			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
++			wakeup-source;
+ 		};
+ 	};
+ 
+-- 
+Armbian
+

--- a/recipes-kernel/linux/linux-mainline/orange-pi-prime/0002-dts-sun50i-h5-orange-pi-prime-add-regulator.patch
+++ b/recipes-kernel/linux/linux-mainline/orange-pi-prime/0002-dts-sun50i-h5-orange-pi-prime-add-regulator.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Mon, 24 Jan 2022 19:34:31 +0300
+Subject: arm64:dts: sun50i-h5-orangepi-prime add regulator
+
+---
+ .../allwinner/sun50i-h5-orangepi-prime.dts    | 30 +++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+index 998396bc0..6dc6850c1 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+@@ -8,6 +8,7 @@
+ 
+ #include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/sun4i-a10.h>
+ 
+ / {
+ 	model = "Xunlong Orange Pi Prime";
+@@ -93,6 +94,10 @@ wifi_pwrseq: wifi_pwrseq {
+ 	};
+ };
+ 
++&cpu0 {
++	cpu-supply = <&reg_vdd_cpux>;
++};
++
+ &codec {
+ 	allwinner,audio-routing =
+ 		"Line Out", "LINEOUT",
+@@ -188,6 +193,31 @@ &ohci3 {
+ 	status = "okay";
+ };
+ 
++&r_i2c {
++	status = "okay";
++
++	reg_vdd_cpux: regulator@65 {
++		compatible = "silergy,sy8106a";
++		reg = <0x65>;
++		regulator-name = "vdd-cpux";
++		silergy,fixed-microvolt = <1200000>;
++		/*
++		 * The datasheet uses 1.1V as the minimum value of VDD-CPUX,
++		 * however both the Armbian DVFS table and the official one
++		 * have operating points with voltage under 1.1V, and both
++		 * DVFS table are known to work properly at the lowest
++		 * operating point.
++		 *
++		 * Use 1.0V as the minimum voltage instead.
++		 */
++		regulator-min-microvolt = <1000000>;
++		regulator-max-microvolt = <1400000>;
++		regulator-ramp-delay = <200>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++};
++
+ &uart0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart0_pa_pins>;
+-- 
+2.25.1

--- a/recipes-kernel/linux/linux-mainline/orange-pi-prime/0003-dts-sun50i-h5-orange-pi-prime-add-rtl8723cs.patch
+++ b/recipes-kernel/linux/linux-mainline/orange-pi-prime/0003-dts-sun50i-h5-orange-pi-prime-add-rtl8723cs.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Mon, 7 Feb 2022 19:11:07 +0300
+Subject: arm64:dts: sun50i-h5-orangepi-prime add rtl8723cs
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+index 8b92d5e77220..f430acd8558f 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+@@ -25,6 +25,7 @@ reg_vcc3v3: vcc3v3 {
+ 	aliases {
+ 		ethernet0 = &emac;
+ 		serial0 = &uart0;
++		ethernet1 = &rtl8723cs;
+ 	};
+ 
+ 	chosen {
+@@ -174,6 +175,10 @@ &mmc1 {
+ 	bus-width = <4>;
+ 	non-removable;
+ 	status = "okay";
++
++	rtl8723cs: sdio_wifi@1 {
++		reg = <1>;
++	};
+ };
+ 
+ &ohci0 {
+-- 
+Armbian
+


### PR DESCRIPTION
- Ethernet, WiFi, Bluetooth, USBs are working fine but HDMI is working until U-Boot loading the kernel. Then it stop working.
- Tested with core-image-base and kernel mainline 6.6.28