### PR TITLE
Fix various Yocto compatibility issues

### DIFF
--- a/recipes-bsp/trusted-firmware-a/trusted-firmware-a_%.bbappend
+++ b/recipes-bsp/trusted-firmware-a/trusted-firmware-a_%.bbappend
@@ -1,7 +1,7 @@
-COMPATIBLE_MACHINE = "(sun50i|sun50i-h616|sun50i-h6)"
+COMPATIBLE_MACHINE:sunxi = "(sun50i|sun50i-h616|sun50i-h6)"
 
 TFA_PLATFORM:sun50i = "sun50i_a64"
 TFA_PLATFORM:sun50i-h6 = "sun50i_h6"
 TFA_PLATFORM:sun50i-h616 = "sun50i_h616"
 
-TFA_BUILD_TARGET = "bl31"
+TFA_BUILD_TARGET:sunxi = "bl31"

--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -1,1 +1,1 @@
-DEPENDS += "libxshmfence"
+PACKAGECONFIG[dri3] = "-Ddri3=true,-Ddri3=false,libxshmfence"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -6,7 +6,7 @@
 # WARNING: The following commit is required for NVRAM files to be included in
 # linux-firmware-bcm43430 package:
 # http://git.openembedded.org/openembedded-core/commit/?id=dde0f79f32fa6bab045ef60199903f74c4cc3393
-do_install:append() {
+do_install:append:sunxi() {
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.xunlong,orangepi-zero-plus2.txt
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.xunlong,orangepi-zero-plus2-h3.txt
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.friendlyarm,nanopi-neo-plus2.txt

--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "Linux Kernel"
 SECTION = "kernel"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 
 INC_PR = "r0"
 


### PR DESCRIPTION
Start a bit of work towards [Yocto Compatibility](https://docs.yoctoproject.org/dev-manual/layers.html#making-sure-your-layer-is-compatible-with-yocto-project). In particular, avoid changing the behaviour of certain recipes based solely on the presence of the meta-sunxi layer.

With these changes the behaviour of several recipes no longer change unless we're using a sunxi machine.