### PR TITLE
pya20: Make olinuxino-a20lime2-emmc a relative symlink

### DIFF
--- a/recipes-devtools/python/files/olinuxino-a20lime2-emmc
+++ b/recipes-devtools/python/files/olinuxino-a20lime2-emmc
@@ -1,1 +1,1 @@
-/home/marek/data/projects/kas/sources/meta-sunxi/recipes-devtools/python/files/olinuxino-a20lime2
+olinuxino-a20lime2


### PR DESCRIPTION
After I raised #410 it was fixed, but now I there is an absolute symlink in the repo which won't work on my machine :)
This makes it relative.