### PR TITLE
recipes: Switch away from S = WORKDIR and use UNPACKDIR instead of WO…

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,4 +14,4 @@ LAYERVERSION_sunxi = "1"
 
 LAYERDEPENDS_sunxi = "core meta-python meta-arm"
 
-LAYERSERIES_COMPAT_sunxi = "honister kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_sunxi = "styhead"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -12,12 +12,12 @@ DEFAULT_PREFERENCE:sun8i = "1"
 DEFAULT_PREFERENCE:sun50i = "1"
 
 SRC_URI:append:sunxi = " \
-	file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
-	file://0002-Added-nanopi-r1-board-support.patch \
-	file://0003-sunxi-H6-Enable-Ethernet-on-Orange-Pi-One-Plus.patch \
-  file://0004-mangopi-mq-r-t113-Fix-serial-console.patch \
-  file://0004-OrangePi-3-LTS-support.patch \
-  file://boot.cmd \
+    file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
+    file://0002-Added-nanopi-r1-board-support.patch \
+    file://0003-sunxi-H6-Enable-Ethernet-on-Orange-Pi-One-Plus.patch \
+    file://0004-mangopi-mq-r-t113-Fix-serial-console.patch \
+    file://0004-OrangePi-3-LTS-support.patch \
+    file://boot.cmd \
 "
 
 UBOOT_ENV_SUFFIX:sunxi = "scr"
@@ -29,5 +29,5 @@ EXTRA_OEMAKE:append:sun50i = " BL31=${DEPLOY_DIR_IMAGE}/bl31.bin SCP=/dev/null"
 do_compile:sun50i[depends] += "trusted-firmware-a:do_deploy"
 
 do_compile:append:sunxi() {
-    ${B}/tools/mkimage -C none -A arm -T script -d ${WORKDIR}/boot.cmd ${WORKDIR}/${UBOOT_ENV_BINARY}
+    ${B}/tools/mkimage -C none -A arm -T script -d ${UNPACKDIR}/boot.cmd ${UNPACKDIR}/${UBOOT_ENV_BINARY}
 }

--- a/recipes-devtools/python/pya20_0.2.12.bb
+++ b/recipes-devtools/python/pya20_0.2.12.bb
@@ -16,7 +16,7 @@ S = "${WORKDIR}/pyA20-${PV}"
 inherit distutils3
 
 do_compile:prepend() { 
-cp ${WORKDIR}/mapping.h ${S}/pyA20/gpio/mapping.h
+    cp ${UNPACKDIR}/mapping.h ${S}/pyA20/gpio/mapping.h
 }
 
 SRC_URI[md5sum] = "cab03b4931199804603d1074f6d8f48f"

--- a/recipes-graphics/xorg-xserver/xf86-video-fbturbo_git.bb
+++ b/recipes-graphics/xorg-xserver/xf86-video-fbturbo_git.bb
@@ -20,7 +20,7 @@ CFLAGS += " -I${STAGING_INCDIR}/xorg "
 
 do_install:append() {
     install -d ${D}${datadir}/X11/xorg.conf.d
-    install -m 0644 ${WORKDIR}/20-fbturbo.conf ${D}${datadir}/X11/xorg.conf.d
+    install -m 0644 ${UNPACKDIR}/20-fbturbo.conf ${D}${datadir}/X11/xorg.conf.d
 }
 
 FILES:${PN} += "${datadir}/X11/xorg.conf.d/20-fbturbo.conf"

--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -45,8 +45,8 @@ do_configure:prepend() {
     #
     # logo support, if you supply logo_linux_clut224.ppm in SRC_URI, then it's going to be used
     #
-    if [ -e ${WORKDIR}/logo_linux_clut224.ppm ]; then
-        install -m 0644 ${WORKDIR}/logo_linux_clut224.ppm drivers/video/logo/logo_linux_clut224.ppm
+    if [ -e ${UNPACKDIR}/logo_linux_clut224.ppm ]; then
+        install -m 0644 ${UNPACKDIR}/logo_linux_clut224.ppm drivers/video/logo/logo_linux_clut224.ppm
         kernel_conf_variable LOGO y
         kernel_conf_variable LOGO_LINUX_CLUT224 y
     fi

--- a/recipes-kernel/uwe5622-firmware/uwe5622-firmware.bb
+++ b/recipes-kernel/uwe5622-firmware/uwe5622-firmware.bb
@@ -2,7 +2,8 @@ DESCRIPTION = "UWE5622 Wifi firmware"
 LICENSE = "CC0-1.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=0ceb3372c9595f0a8067e55da801e4a1"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 COMPATIBLE_MACHINE = "(orange-pi-zero2|orange-pi-3lts)"
 


### PR DESCRIPTION
…RKDIR

- The layer compability has also been updated in this PR.

* Using S = ${WORKDIR} is no longer supported.

* UNPACKDIR is new contruct for do_unpack things in latest master we should be using that instead of WORKDIR for referencing those files.

* We don't know yet what changes will be needed to stay compatible with final styhead, but we already know that the last changes for UNPACKDIR aren't compatible with scarthgap, nanbield or others.

https://lists.openembedded.org/g/openembedded-architecture/message/2007 
https://docs.yoctoproject.org/next/migration-guides/migration-5.1.html#workdir-changes