### PR TITLE
linux: change licence name

### DIFF
--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "Linux Kernel"
 SECTION = "kernel"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 
 INC_PR = "r0"
 


### PR DESCRIPTION
Use SPDX name for the kernel, oe-core changed a long time ago and now we're throwing licence name warnings.

Cherry-picked f8aeeaeddb2357bfa15bc2b56ce6f44361b60bb1 from branch master as it relevant to branch scarthgap too.