### PR TITLE
xradio-firmware: Add branch to SRC_URI

### DIFF
--- a/recipes-kernel/xradio-firmware/xradio-firmware.bb
+++ b/recipes-kernel/xradio-firmware/xradio-firmware.bb
@@ -9,7 +9,7 @@ SRCREV = "761658e1701c77a0a84706754e6db1a25ee60b82"
 
 COMPATIBLE_MACHINE = "orange-pi-zero"
 
-SRC_URI = "git://github.com/armbian/firmware.git;protocol=https"
+SRC_URI = "git://github.com/armbian/firmware.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Explicitly specify a branch parameter and fix the warning:

The future default branch used by tools and repositories is uncertain and we will therefore soon require this is set in all git urls.