### PR TITLE
fix(scarthgap): replace xf86-input-keyboard with xf86-input-libinput …

### DIFF
--- a/conf/machine/include/sunxi.inc
+++ b/conf/machine/include/sunxi.inc
@@ -11,7 +11,7 @@ PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 XSERVER = "xserver-xorg \
            xf86-input-evdev \
            xf86-input-mouse \
-           xf86-input-keyboard"
+           xf86-input-libinput"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-mainline"
 PREFERRED_VERSION_linux-mainline ?= "6.6.%"


### PR DESCRIPTION
…in Yocto

The xf86-input-keyboard package is obsolete and has been replaced by libinput/evdev as per the migration guide (migration-4.1.rst). This commit addresses the error "ERROR: Nothing RPROVIDES 'xf86-input-keyboard'" by updating the dependency to xf86-input-libinput.