### PR TITLE
u-boot: apply ttyS3 patch only for mangopi-mq-t-tt13 builds

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -15,10 +15,13 @@ SRC_URI:append:sunxi = " \
     file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
     file://0002-Added-nanopi-r1-board-support.patch \
     file://0003-sunxi-H6-Enable-Ethernet-on-Orange-Pi-One-Plus.patch \
-    file://0004-mangopi-mq-r-t113-Fix-serial-console.patch \
     file://0004-OrangePi-3-LTS-support.patch \
     file://boot.cmd \
 "
+
+SRC_URI:append:mangopi-mq-t-t113 = " \
+    file://0004-mangopi-mq-r-t113-Fix-serial-console.patch \
+    "
 
 UBOOT_ENV_SUFFIX:sunxi = "scr"
 UBOOT_ENV:sunxi = "boot"


### PR DESCRIPTION
For all boards except mangopi-mq-t-tt13, switch back the serial console to ttyS0. Apply the ttyS3 patch added in commit [1] only when building for the mangopi-mq-t-tt13 board.

Boot tested on orangepi-zero2 board - the kernel logs are again printed to the debug serial console.

    [1] 9edbede7bcc3 ("u-boot: Fix console for mangopi-mq-r-tt13 board")