### PR TITLE
layer.conf: set BB_DANGLINGAPPENDS_WARNONLY

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -15,3 +15,5 @@ LAYERVERSION_sunxi = "1"
 LAYERDEPENDS_sunxi = "core meta-python meta-arm"
 
 LAYERSERIES_COMPAT_sunxi = "styhead"
+
+BB_DANGLINGAPPENDS_WARNONLY = "1"


### PR DESCRIPTION
A simple core-image-base build on master branch results in the following "No recipes in default available" error:

  git clone https://github.com/openembedded/bitbake.git
  git clone https://github.com/openembedded/openembedded-core.git
  git clone https://github.com/openembedded/meta-openembedded.git
  git clone git://git.yoctoproject.org/meta-arm
  git clone https://github.com/linux-sunxi/meta-sunxi.git

  . openembedded-core/oe-init-build-env build-orange-pi-zero2
  bitbake-layers add-layer ../meta-openembedded/meta-oe/
  bitbake-layers add-layer ../meta-openembedded/meta-python
  bitbake-layers add-layer ../meta-arm/meta-arm-toolchain/
  bitbake-layers add-layer ../meta-arm/meta-arm
  bitbake-layers add-layer ../meta-sunxi

  echo 'MACHINE="orange-pi-zero2"' >> conf/local.conf

  bitbake core-image-base
  ...
  ERROR: No recipes in default available for:
    <path>/meta-sunxi/recipes-graphics/mesa/mesa-gl_%.bbappend
    <path>/meta-sunxi/recipes-graphics/mesa/mesa_%.bbappend

While mesa and mesa-gl recipes are present in openembedded-core layer, they are not buildable unless opengl or vulkan distro feature is enabled:
  cat openembedded-core/meta/recipes-graphics/mesa/mesa.inc
  ...
  ANY_OF_DISTRO_FEATURES = "opengl vulkan"

Set BB_DANGLINGAPPENDS_WARNONLY = "1" in layer.conf to turn this build error to a non-fatal warning.