### PR TITLE
cubieboard4.conf: Add machine

### DIFF
--- a/conf/machine/cubieboard4.conf
+++ b/conf/machine/cubieboard4.conf
@@ -1,0 +1,10 @@
+#@TYPE: Machine
+#@NAME: CubieBoard4
+#@DESCRIPTION: Machine configuration for the cubieboard4, based on allwinner A80 CPU http://cubieboard.org/
+
+require conf/machine/include/sun9i.inc
+
+KERNEL_IMAGETYPE = "zImage"
+
+KERNEL_DEVICETREE = "sun9i-a80-cubieboard4.dtb"
+UBOOT_MACHINE = "Cubieboard4_defconfig"


### PR DESCRIPTION
Add machine `cubieboard4` for Cubieboard 4 with Allwinner A80 SoC from the sun9i family with mainline U-Boot and Linux kernel.

Thanks to @lazarh for testing core-image-base on the machine.