### PR TITLE
recipes/devtools: replace distutils3*.bbclass with setuptools3*.bbclass

### DIFF
--- a/recipes-devtools/python/pya20_0.2.12.bb
+++ b/recipes-devtools/python/pya20_0.2.12.bb
@@ -13,7 +13,7 @@ SRC_URI = "https://pypi.python.org/packages/source/p/pyA20/pyA20-${PV}.tar.gz \
           "
 S = "${WORKDIR}/pyA20-${PV}"
 
-inherit distutils3
+inherit setuptools3
 
 do_compile:prepend() { 
     cp ${UNPACKDIR}/mapping.h ${S}/pyA20/gpio/mapping.h


### PR DESCRIPTION
distutils3 is deprecated and its use produces warnings during build:
~~~
WARNING: distutils-common-base.bbclass is deprecated, please use setuptools3-base.bbclass instead
WARNING: distutils3-base.bbclass is deprecated, please use setuptools3-base.bbclass instead
WARNING: distutils3.bbclass is deprecated, please use setuptools3.bbclass instead
~~~
setuptools3 should be a drop-in replacement.