### PR TITLE
Add BananaPi M2 Berry support

### DIFF
--- a/conf/machine/bananapi-m2-berry.conf
+++ b/conf/machine/bananapi-m2-berry.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+#@NAME: bananapi-m2-berry
+#@DESCRIPTION: Machine configuration for the Banana Pi M2 Berry, based on Allwinner V40 CPU
+
+require conf/machine/include/sun8i.inc
+require conf/machine/include/hardware/ap6212a.inc
+
+KERNEL_DEVICETREE = "sun8i-v40-bananapi-m2-berry.dtb"
+UBOOT_MACHINE = "bananapi_m2_berry_defconfig"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -10,6 +10,7 @@ do_install:append:sunxi() {
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.xunlong,orangepi-zero-plus2.txt
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.xunlong,orangepi-zero-plus2-h3.txt
 	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.friendlyarm,nanopi-neo-plus2.txt
+	ln -sf -r ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.AP6212.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.sinovoip,bpi-m2-berry.txt
 }
 
 do_install:append:cubieboard4() {

--- a/recipes-kernel/linux/linux-mainline.inc
+++ b/recipes-kernel/linux/linux-mainline.inc
@@ -68,6 +68,7 @@ SOURCES = " \
 
 SRC_URI:append:use-mailine-graphics = " file://drm.cfg"
 SRC_URI:append:bananapi = " file://axp20x.cfg"
+SRC_URI:append:bananapi-m2-berry = " file://axp20x.cfg"
 SRC_URI:append:bananapi-m2-zero = " file://axp20x.cfg"
 SRC_URI:append:cubietruck = " file://axp20x.cfg"
 SRC_URI:append:nanopi-neo-air = " file://cam500b.cfg"


### PR DESCRIPTION
Add `bananapi-m2-berry` machine conf and enable WiFi for it.

I didn't test much, but I was able to start `core-image-weston` after increasing CMA size via kernel cmdline and ping stuff via WiFi.

Let me know if you need more info or testing, thanks!