### PR TITLE
linux-mainline: bump to 6.6.85

### DIFF
--- a/recipes-kernel/linux/linux-mainline_6.6.85.bb
+++ b/recipes-kernel/linux/linux-mainline_6.6.85.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${KRELEASE}.x/linux-${PV}.tar.xz \
            file://sunxi-kmeta;type=kmeta;name=sunxi-kmeta;destsuffix=sunxi-kmeta \
            "
-SRC_URI[sha256sum] = "818716ed13e7dba6aaeae24e3073993e260812ed128d10272e94b922ee6d3394"
+SRC_URI[sha256sum] = "5ebaccf4ca3428cd26817bae62171f4efd270eed866a3e3d0a1d9e970b7b7529"
 
 
 KERNEL_FEATURES:prepend:orange-pi-3lts = " bsp/orange-pi-3lts/orange-pi-3lts-6_5.scc bsp/uwe5622/uwe5622-6_6.scc bsp/orange-pi-3lts/fix-rtc.scc"


### PR DESCRIPTION
Update to latest patch release for bug and CVE fixes
