### PR TITLE
Support Walnascar

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,4 +14,4 @@ LAYERVERSION_sunxi = "1"
 
 LAYERDEPENDS_sunxi = "core meta-python meta-arm"
 
-LAYERSERIES_COMPAT_sunxi = "styhead"
+LAYERSERIES_COMPAT_sunxi = "walnascar"

--- a/recipes-kernel/linux/linux.inc
+++ b/recipes-kernel/linux/linux.inc
@@ -35,9 +35,10 @@ kernel_conf_variable() {
     fi
 }
 
-do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}binutils:do_populate_sysroot"
-do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
+do_kernel_configme[depends] += "virtual/cross-binutils:do_populate_sysroot"
+do_kernel_configme[depends] += "virtual/cross-cc:do_populate_sysroot"
 do_kernel_configme[depends] += "bc-native:do_populate_sysroot bison-native:do_populate_sysroot"
+do_kernel_configme[depends] += "kern-tools-native:do_populate_sysroot"
 
 do_configure:prepend() {
     CONF_SED_SCRIPT=""


### PR DESCRIPTION
- conf/layer.conf:Support Yocto release Walnascar.
- linux.inc: Switch from virtual/XXX-gcc to virtual/cross-cc (and c++/binutils) as in [Poky commit 90e0a0f7f4536e1aeb311ab2b061be71b4129e4e](https://web.git.yoctoproject.org/poky/commit/?id=90e0a0f7f4536e1aeb311ab2b061be71b4129e4e)