### PR TITLE
Add support for Olimex A20-SOM204-EVB board 

### DIFF
--- a/conf/machine/olinuxino-a20som204.conf
+++ b/conf/machine/olinuxino-a20som204.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+#@NAME: Olimex A20-SOM204
+#@DESCRIPTION: Machine configuration for the Olimex A20-SOM204 Evaluation Board, based on Allwinner A20 CPU
+#https://github.com/OLIMEX/SOM204
+
+require conf/machine/include/sun7i.inc
+
+KERNEL_DEVICETREE = "allwinner/sun7i-a20-olimex-som204-evb.dtb"
+UBOOT_MACHINE = "A20-Olimex-SOM204-EVB_defconfig"

--- a/recipes-devtools/python/pya20_0.2.12.bb
+++ b/recipes-devtools/python/pya20_0.2.12.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://PKG-INFO;md5=4e584373bb0f46ef1e423cb7df37847d"
 DEPENDS = "python3"
 
 # No GPIO mappings for other machines yet
-COMPATIBLE_MACHINE = "(olinuxino-a13|olinuxino-a10|olinuxino-a20|olinuxino-a10lime|olinuxino-a20lime|olinuxino-a20lime2|olinuxino-a13som|olinuxino-a20som)"
+COMPATIBLE_MACHINE = "^(olinuxino-a13|olinuxino-a10|olinuxino-a20|olinuxino-a10lime|olinuxino-a20lime|olinuxino-a20lime2|olinuxino-a13som|olinuxino-a20som)$"
 
 SRC_URI = "https://pypi.python.org/packages/source/p/pyA20/pyA20-${PV}.tar.gz \
            file://mapping.h \


### PR DESCRIPTION
Add support for Olimex A20-SOM204-EVB board. It is an expansion board
for the Olimex A20-SOM204 SOM that uses the sun7i Allwinner A20 Soc:
https://github.com/OLIMEX/SOM204

It is supported in U-Boot and mainline Linux kernel.