### PR TITLE
Fix EMAC Probiing error for orangepi one plus

### DIFF
--- a/recipes-kernel/linux/linux-mainline/patches/0002-dts-orange-pi-one-plus-Add-Enable-Ethernet.patch
+++ b/recipes-kernel/linux/linux-mainline/patches/0002-dts-orange-pi-one-plus-Add-Enable-Ethernet.patch
@@ -1,0 +1,40 @@
+From d547db3a6067b670995f7479cf6cec49ac09ef94 Mon Sep 17 00:00:00 2001
+From: Mark Choi <afewgoodman.choi@gmail.com>
+Date: Tue, 24 Feb 2026 14:33:42 +0900
+Subject: [PATCH] dts orange pi one plus Add Enable Ethernet
+
+1. Add compatible to specifiy RTL8211.
+This was fixed in U-boot.
+
+https://patchwork.ozlabs.org/project/uboot/patch/20230711003957.658805-2-retpolanne@posteo.net/#3148293
+
+2. Add reset pin definition(PD14) for RTL8211.
+reset pin is required for if up/down function.
+
+Upstream-Status: Pending
+
+Signed-off-by: Mark Choi <afewgoodman.choi@gmail.com>
+---
+ .../boot/dts/allwinner/sun50i-h6-orangepi-one-plus.dts      | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-one-plus.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-one-plus.dts
+index 29a081e72..769716c0e 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-one-plus.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-one-plus.dts
+@@ -37,7 +37,11 @@ &emac {
+ 
+ &mdio {
+ 	ext_rgmii_phy: ethernet-phy@1 {
+-		compatible = "ethernet-phy-ieee802.3-c22";
++		compatible = "ethernet-phy-id001c.c915", "ethernet-phy-ieee802.3-c22";
+ 		reg = <1>;
++		reset-gpios = <&pio 3 14 GPIO_ACTIVE_LOW>; /* PD14 */
++		reset-assert-us = <10000>;
++		reset-deassert-us = <50000>;
++
+ 	};
+ };
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-mainline_6.6.85.bbappend
+++ b/recipes-kernel/linux/linux-mainline_6.6.85.bbappend
@@ -1,4 +1,5 @@
 
 SRC_URI:append:orange-pi-one-plus = " file://axp20x.cfg"
 SRC_URI:append:orange-pi-one-plus = " file://patches/0001-dts-allwinner-Orangepi-one-plus-Fixed-pmic-error.patch"
+SRC_URI:append:orange-pi-one-plus = " file://patches/0002-dts-orange-pi-one-plus-Add-Enable-Ethernet.patch"
 


### PR DESCRIPTION
U-boot probe emac correctly but, kernel does not.

There were two issues.

1. U-boot specified compatible for RTL8211 in dts, but kernel. 
  -.  https://patchwork.ozlabs.org/project/uboot/patch/20230711003957.658805-2-retpolanne@posteo.net/#3148293

3. Kernel require reset pin for it and controlling. 
  -. Add reset pin gpio PD14 and its delays.

[    5.478245] dwmac-sun8i 5020000.ethernet: IRQ eth_wake_irq not found
[    5.520814] dwmac-sun8i 5020000.ethernet: IRQ eth_lpi not found
[    5.538568] dwmac-sun8i 5020000.ethernet: PTP uses main clock
[    5.544627] dwmac-sun8i 5020000.ethernet: Current syscon value is not the default 50846 (expect 50000)
[    5.667069] dwmac-sun8i 5020000.ethernet: No HW DMA feature register supported
[    5.674399] dwmac-sun8i 5020000.ethernet: RX Checksum Offload Engine supported
[    5.674410] dwmac-sun8i 5020000.ethernet: COE Type 2
[    5.674417] dwmac-sun8i 5020000.ethernet: TX Checksum insertion supported
[    5.674424] dwmac-sun8i 5020000.ethernet: Normal descriptors
[    5.674430] dwmac-sun8i 5020000.ethernet: Chain mode enabled
[    5.676599] mdio_bus stmmac-0: MDIO device at address 1 is missing.
[    5.813179] dwmac-sun8i 5020000.ethernet: EMAC reset timeout
[    5.818898] dwmac-sun8i 5020000.ethernet eth0: stmmac_dvr_remove: removing driver
[    5.850571] dwmac-sun8i: probe of 5020000.ethernet failed with error -110