### PR TITLE
Use UBOOT_MKIMAGE command in compile

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -35,5 +35,5 @@ EXTRA_OEMAKE:append:sun50i = " BL31=${DEPLOY_DIR_IMAGE}/bl31.bin SCP=/dev/null"
 do_compile:sun50i[depends] += "trusted-firmware-a:do_deploy"
 
 do_compile:append:sunxi() {
-    ${B}/tools/mkimage -C none -A arm -T script -d ${UNPACKDIR}/boot.cmd ${UNPACKDIR}/${UBOOT_ENV_BINARY}
+    ${UBOOT_MKIMAGE} -C none -A arm -T script -d ${UNPACKDIR}/boot.cmd ${UNPACKDIR}/${UBOOT_ENV_BINARY}
 }


### PR DESCRIPTION
When using multiple uboot configurations, uboot will fail to compile. Using the UBOOT_MKIMAGE variable in the compile command instead of the hard-coded path fixes this.

More info about UBOOT_CONFIG here:
https://docs.yoctoproject.org/ref-manual/variables.html#term-UBOOT_CONFIG 