### PR TITLE
Fix whitespace in u-boot-sunxi.bb

### DIFF
--- a/recipes-bsp/u-boot/u-boot-sunxi.bb
+++ b/recipes-bsp/u-boot/u-boot-sunxi.bb
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i)"
 
-DEFAULT_PREFERENCE_sun4i="1"
-DEFAULT_PREFERENCE_sun5i="1"
-DEFAULT_PREFERENCE_sun7i="1"
+DEFAULT_PREFERENCE_sun4i = "1"
+DEFAULT_PREFERENCE_sun5i = "1"
+DEFAULT_PREFERENCE_sun7i = "1"
 
 # Sunxi U-Boot uses different names for some boards
 UBOOT_MACHINE_olinuxino-a20 = "A20-OLinuXino-Micro_config"
@@ -33,7 +33,7 @@ SRCREV = "ea1ac32bf76eb60baef474c2516fc431b381d952"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-SPL_BINARY="u-boot-sunxi-with-spl.bin"
+SPL_BINARY = "u-boot-sunxi-with-spl.bin"
 
 do_configure () {
     oe_runmake -C ${S} O=${B} ${UBOOT_MACHINE}


### PR DESCRIPTION
In yocto 6.0 there is a warning for lack of whitespace in u-boot-sunxi.bb This commit fixes those warnings.

```
WARNING: meta-sunxi/recipes-bsp/u-boot/u-boot-sunxi.bb:12 has a lack of whitespace around the assignment: 'DEFAULT_PREFERENCE_sun4i="1"'
WARNING: meta-sunxi/recipes-bsp/u-boot/u-boot-sunxi.bb:13 has a lack of whitespace around the assignment: 'DEFAULT_PREFERENCE_sun5i="1"'
WARNING: meta-sunxi/recipes-bsp/u-boot/u-boot-sunxi.bb:14 has a lack of whitespace around the assignment: 'DEFAULT_PREFERENCE_sun7i="1"'
WARNING: meta-sunxi/recipes-bsp/u-boot/u-boot-sunxi.bb:36 has a lack of whitespace around the assignment: 'SPL_BINARY="u-boot-sunxi-with-spl.bin"'
```