### PR TITLE
u-boot: fix BL31 deploy path

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -30,7 +30,7 @@ UBOOT_ENV_SUFFIX:sunxi = "scr"
 UBOOT_ENV:sunxi = "boot"
 
 EXTRA_OEMAKE:append:sunxi = ' HOSTLDSHARED="${BUILD_CC} -shared ${BUILD_LDFLAGS} ${BUILD_CFLAGS}" '
-EXTRA_OEMAKE:append:sun50i = " BL31=${DEPLOY_DIR_IMAGE}/bl31.bin SCP=/dev/null"
+EXTRA_OEMAKE:append:sun50i = " BL31=${DEPLOY_DIR_IMAGE}/trusted-firmware-a/bl31.bin SCP=/dev/null"
 
 do_compile:sun50i[depends] += "trusted-firmware-a:do_deploy"
 


### PR DESCRIPTION
The trusted-firmware-a recipe now deploys BL31 under the trusted-firmware-a subdirectory. Update the U-Boot build arguments to use the actual deployed path.