### PR TITLE
linux-mainline: update to latest LTS 6.18

### DIFF
--- a/conf/machine/include/sunxi.inc
+++ b/conf/machine/include/sunxi.inc
@@ -14,7 +14,7 @@ XSERVER = "xserver-xorg \
            xf86-input-keyboard"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-mainline"
-PREFERRED_VERSION_linux-mainline ?= "6.6.%"
+PREFERRED_VERSION_linux-mainline ?= "6.18.%"
 PREFERRED_PROVIDER_u-boot ?= "u-boot"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
 

--- a/conf/machine/include/sunxi64.inc
+++ b/conf/machine/include/sunxi64.inc
@@ -4,7 +4,7 @@ include conf/machine/include/soc-family.inc
 MACHINEOVERRIDES =. "sunxi:sunxi64:"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-mainline"
-PREFERRED_VERSION_linux-mainline ?= "6.6.%"
+PREFERRED_VERSION_linux-mainline ?= "6.18.%"
 PREFERRED_PROVIDER_u-boot ?= "u-boot"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
 

--- a/recipes-kernel/linux/linux-mainline/patches/0001-dts-orangepi-zero-Add-wifi-support.patch
+++ b/recipes-kernel/linux/linux-mainline/patches/0001-dts-orangepi-zero-Add-wifi-support.patch
@@ -1,4 +1,4 @@
-From a9bad790ae9a9e9befbe8e8938b6baca84ee5138 Mon Sep 17 00:00:00 2001
+From db7d97b28765b8d466bd0eda744899b6b8d8d033 Mon Sep 17 00:00:00 2001
 From: Marek Belisko <marek.belisko@open-nandra.com>
 Date: Tue, 24 Oct 2023 10:40:52 +0200
 Subject: [PATCH] dts: orangepi-zero: Add wifi support
@@ -6,19 +6,20 @@ Subject: [PATCH] dts: orangepi-zero: Add wifi support
 Upstream-Status: Pending
 
 Signed-off-by: Marek Belisko <marek.belisko@open-nandra.com>
+Signed-off-by: Dmitry Sakhonchik <frezidok1@gmail.com>
 ---
- .../allwinner/sun8i-h2-plus-orangepi-zero.dts | 46 +++++++++++++++----
- 1 file changed, 37 insertions(+), 9 deletions(-)
+ .../allwinner/sun8i-h2-plus-orangepi-zero.dts | 44 +++++++++++++++----
+ 1 file changed, 35 insertions(+), 9 deletions(-)
 
 diff --git a/arch/arm/boot/dts/allwinner/sun8i-h2-plus-orangepi-zero.dts b/arch/arm/boot/dts/allwinner/sun8i-h2-plus-orangepi-zero.dts
-index 3706216ff..ca94e313f 100644
+index 9abe087b6..5c74a6a84 100644
 --- a/arch/arm/boot/dts/allwinner/sun8i-h2-plus-orangepi-zero.dts
 +++ b/arch/arm/boot/dts/allwinner/sun8i-h2-plus-orangepi-zero.dts
-@@ -80,13 +80,15 @@ status_led {
+@@ -83,13 +83,14 @@ status_led {
  		};
  	};
  
--	reg_vcc_wifi: reg_vcc_wifi {
+-	reg_vcc_wifi: reg-vcc-wifi {
 +	vdd_wifi: vdd_wifi {
  		compatible = "regulator-fixed";
 -		regulator-min-microvolt = <3300000>;
@@ -31,15 +32,14 @@ index 3706216ff..ca94e313f 100644
  		gpio = <&pio 0 20 GPIO_ACTIVE_HIGH>;
 +		startup-delay-us = <70000>;
 +		enable-active-high;
-+
  	};
  
  	reg_vdd_cpux: vdd-cpux-regulator {
-@@ -105,10 +107,12 @@ reg_vdd_cpux: vdd-cpux-regulator {
+@@ -108,10 +109,12 @@ reg_vdd_cpux: vdd-cpux-regulator {
  		states = <1100000 0>, <1300000 1>;
  	};
  
--	wifi_pwrseq: wifi_pwrseq {
+-	wifi_pwrseq: pwrseq {
 +	pwrseq_wifi: pwrseq_wifi {
  		compatible = "mmc-pwrseq-simple";
 +		pinctrl-names = "default";
@@ -50,7 +50,7 @@ index 3706216ff..ca94e313f 100644
  	};
  };
  
-@@ -139,9 +143,11 @@ &mmc0 {
+@@ -156,9 +159,11 @@ &mmc0 {
  };
  
  &mmc1 {
@@ -64,9 +64,9 @@ index 3706216ff..ca94e313f 100644
  	non-removable;
  	status = "okay";
  
-@@ -151,6 +157,13 @@ &mmc1 {
+@@ -168,6 +173,13 @@ &mmc1 {
  	 */
- 	xr819: sdio_wifi@1 {
+ 	xr819: wifi@1 {
  		reg = <1>;
 +		compatible = "xradio,xr819";
 +		pinctrl-names = "default";
@@ -78,7 +78,7 @@ index 3706216ff..ca94e313f 100644
  	};
  };
  
-@@ -207,3 +220,18 @@ &usbphy {
+@@ -224,3 +236,17 @@ &usbphy {
  	status = "okay";
  	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
  };
@@ -96,7 +96,3 @@ index 3706216ff..ca94e313f 100644
 +		function = "gpio_out";
 +    };
 +};
-+
--- 
-2.25.1
-

--- a/recipes-kernel/linux/linux-mainline_6.18.40.bb
+++ b/recipes-kernel/linux/linux-mainline_6.18.40.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 SRC_URI += "https://www.kernel.org/pub/linux/kernel/v${KRELEASE}.x/linux-${PV}.tar.xz \
            file://sunxi-kmeta;type=kmeta;name=sunxi-kmeta;destsuffix=sunxi-kmeta \
            "
-SRC_URI[sha256sum] = "5ebaccf4ca3428cd26817bae62171f4efd270eed866a3e3d0a1d9e970b7b7529"
+SRC_URI[sha256sum] = "3712fc1ec839e4daac981176c8518912e8f452650aaedfe4381da4419613a431"
 
 KERNEL_FEATURES:append:orange-pi-3lts = " bsp/orange-pi-3lts/orange-pi-3lts-6_5.scc bsp/uwe5622/uwe5622-6_6.scc bsp/orange-pi-3lts/fix-rtc.scc"
 KERNEL_FEATURES:append:orange-pi-zero2 = " bsp/h61x/orangepi-zero2-6_6.scc bsp/uwe5622/uwe5622-6_6.scc"


### PR DESCRIPTION
I am working on adding orange pi 4a machine to layer, but its support appeared only in linux 6.17. Since layer uses latest LTS (and now latest LTS is 6.18), I suggest to update to 6.18.40. 
Only one patch (orange pi zero wifi) does not apply and was not upstreamed. I dropped it, because I can't test its runtime functionality. 
I could test only Orange Pi Zero 3 with this new kernel. Works as expected.