### PR TITLE
u-boot: Backport fix of double vendor prefix

### DIFF
--- a/recipes-bsp/u-boot/files/avoid_double_vendor_prefix.patch
+++ b/recipes-bsp/u-boot/files/avoid_double_vendor_prefix.patch
@@ -1,0 +1,48 @@
+From eb7390797d262eaab589a4d4e71fbb0c156bd61c Mon Sep 17 00:00:00 2001
+From: Bohdan Chubuk <chbgdn@gmail.com>
+Date: Sun, 23 Nov 2025 22:43:46 +0200
+Subject: [PATCH] sunxi: avoid double vendor prefix when CONFIG_OF_UPSTREAM is
+ enabled
+
+When CONFIG_OF_UPSTREAM is enabled, the device tree name provided by SPL
+already includes the vendor directory (e.g., "allwinner/board-name").
+
+The existing logic in misc_init_r() unconditionally prepends "allwinner/"
+for ARM64 builds, resulting in an incorrect path like
+"allwinner/allwinner/board-name.dtb".
+
+This patch modifies the logic to only prepend the vendor prefix if
+CONFIG_OF_UPSTREAM is NOT enabled. This ensures compatibility with both
+legacy builds and the new upstream devicetree structure.
+
+Signed-off-by: Bohdan Chubuk <chbgdn@gmail.com>
+Reviewed-by: Andre Przywara <andre.przywara@arm.com>
+
+Upstream-Status: Backport [https://git.u-boot-project.org/u-boot/u-boot/-/commit/eb7390797d262eaab589a4d4e71fbb0c156bd61c]
+Signed-off-by: Dmitry Sakhonchik <frezidok1@gmail.com>
+
+---
+ board/sunxi/board.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index 2929bc17f08..e9e3fb9a571 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -834,9 +834,12 @@ int misc_init_r(void)
+ 	/* Set fdtfile to match the FIT configuration chosen in SPL. */
+ 	spl_dt_name = get_spl_dt_name();
+ 	if (spl_dt_name) {
+-		char *prefix = IS_ENABLED(CONFIG_ARM64) ? "allwinner/" : "";
++		const char *prefix = "";
+ 		char str[64];
+ 
++		if (IS_ENABLED(CONFIG_ARM64) && !IS_ENABLED(CONFIG_OF_UPSTREAM))
++			prefix = "allwinner/";
++
+ 		snprintf(str, sizeof(str), "%s%s.dtb", prefix, spl_dt_name);
+ 		env_set("fdtfile", str);
+ 	}
+-- 
+GitLab
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -16,6 +16,7 @@ SRC_URI:append:sunxi = " \
     file://0002-Added-nanopi-r1-board-support.patch \
     file://0003-sunxi-H6-Enable-Ethernet-on-Orange-Pi-One-Plus.patch \
     file://0004-OrangePi-3-LTS-support.patch \
+    file://avoid_double_vendor_prefix.patch \
     file://boot.cmd \
 "
 SRC_URI:append:sun9i = " \


### PR DESCRIPTION
There is an issue in u-boot 2026.01 source code, when vendor prefix is added two times in the separate parts of code, resulting "allwinner/allwinner/board-name.dtb" in the fdtfile variable.

This patch fixes it.