### PR TITLE
Add Orange Pi 4A and sun55i support

### DIFF
--- a/conf/machine/include/sun55i.inc
+++ b/conf/machine/include/sun55i.inc
@@ -1,0 +1,6 @@
+require conf/machine/include/sunxi64.inc
+
+DEFAULTTUNE ?= "cortexa55"
+require conf/machine/include/arm/armv8-2a/tune-cortexa55.inc
+
+SOC_FAMILY = "sun55i"

--- a/conf/machine/orange-pi-4a.conf
+++ b/conf/machine/orange-pi-4a.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: orange-pi-4a
+#@DESCRIPTION: Machine configuration for the orange-pi-4a, based on Allwinner T527 CPU
+
+require conf/machine/include/sun55i.inc
+
+KERNEL_DEVICETREE = "allwinner/sun55i-t527-orangepi-4a.dtb"
+UBOOT_MACHINE = "orangepi_4a_defconfig"
+IMAGE_BOOT_FILES = "${KERNEL_IMAGETYPE} boot.scr ${@d.getVar('KERNEL_DEVICETREE', '').split('/')[-1]};${KERNEL_DEVICETREE}}"
+
+MACHINE_EXTRA_RRECOMMENDS = "kernel-modules"

--- a/recipes-bsp/trusted-firmware-a/trusted-firmware-a_%.bbappend
+++ b/recipes-bsp/trusted-firmware-a/trusted-firmware-a_%.bbappend
@@ -1,7 +1,14 @@
-COMPATIBLE_MACHINE:sunxi = "(sun50i|sun50i-h616|sun50i-h6)"
+COMPATIBLE_MACHINE:sunxi = "(sun50i|sun50i-h616|sun50i-h6|sun55i)"
 
 TFA_PLATFORM:sun50i = "sun50i_a64"
 TFA_PLATFORM:sun50i-h6 = "sun50i_h6"
 TFA_PLATFORM:sun50i-h616 = "sun50i_h616"
+TFA_PLATFORM:sun55i = "sun55i_a523"
 
 TFA_BUILD_TARGET:sunxi = "bl31"
+
+# This branch seems to be ready, but it is in the upstreaming process right now
+SRC_URI:sun55i = \
+    "git://github.com/jernejsk/arm-trusted-firmware.git;protocol=https;branch=a523-v4"
+
+SRCREV:sun55i = "e019f64d91ff7c2dfbbfe7f76a14f240761b9edc"

--- a/recipes-bsp/u-boot/files/avoid_double_vendor_prefix.patch
+++ b/recipes-bsp/u-boot/files/avoid_double_vendor_prefix.patch
@@ -1,0 +1,48 @@
+From eb7390797d262eaab589a4d4e71fbb0c156bd61c Mon Sep 17 00:00:00 2001
+From: Bohdan Chubuk <chbgdn@gmail.com>
+Date: Sun, 23 Nov 2025 22:43:46 +0200
+Subject: [PATCH] sunxi: avoid double vendor prefix when CONFIG_OF_UPSTREAM is
+ enabled
+
+When CONFIG_OF_UPSTREAM is enabled, the device tree name provided by SPL
+already includes the vendor directory (e.g., "allwinner/board-name").
+
+The existing logic in misc_init_r() unconditionally prepends "allwinner/"
+for ARM64 builds, resulting in an incorrect path like
+"allwinner/allwinner/board-name.dtb".
+
+This patch modifies the logic to only prepend the vendor prefix if
+CONFIG_OF_UPSTREAM is NOT enabled. This ensures compatibility with both
+legacy builds and the new upstream devicetree structure.
+
+Signed-off-by: Bohdan Chubuk <chbgdn@gmail.com>
+Reviewed-by: Andre Przywara <andre.przywara@arm.com>
+
+Upstream-Status: Backport [https://git.u-boot-project.org/u-boot/u-boot/-/commit/eb7390797d262eaab589a4d4e71fbb0c156bd61c]
+Signed-off-by: Dmitry Sakhonchik <frezidok1@gmail.com>
+
+---
+ board/sunxi/board.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index 2929bc17f08..e9e3fb9a571 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -834,9 +834,12 @@ int misc_init_r(void)
+ 	/* Set fdtfile to match the FIT configuration chosen in SPL. */
+ 	spl_dt_name = get_spl_dt_name();
+ 	if (spl_dt_name) {
+-		char *prefix = IS_ENABLED(CONFIG_ARM64) ? "allwinner/" : "";
++		const char *prefix = "";
+ 		char str[64];
+ 
++		if (IS_ENABLED(CONFIG_ARM64) && !IS_ENABLED(CONFIG_OF_UPSTREAM))
++			prefix = "allwinner/";
++
+ 		snprintf(str, sizeof(str), "%s%s.dtb", prefix, spl_dt_name);
+ 		env_set("fdtfile", str);
+ 	}
+-- 
+GitLab
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -16,6 +16,7 @@ SRC_URI:append:sunxi = " \
     file://0002-Added-nanopi-r1-board-support.patch \
     file://0003-sunxi-H6-Enable-Ethernet-on-Orange-Pi-One-Plus.patch \
     file://0004-OrangePi-3-LTS-support.patch \
+    file://avoid_double_vendor_prefix.patch \
     file://boot.cmd \
 "
 SRC_URI:append:sun9i = " \

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -2,14 +2,16 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 DEPENDS:append:sunxi = " bc-native dtc-native swig-native python3-native flex-native bison-native "
 DEPENDS:append:sun50i = " trusted-firmware-a"
+DEPENDS:append:sun55i = " trusted-firmware-a"
 
-COMPATIBLE_MACHINE:sunxi = "(sun4i|sun5i|sun7i|sun8i|sun9i|sun50i)"
+COMPATIBLE_MACHINE:sunxi = "(sun4i|sun5i|sun7i|sun8i|sun9i|sun50i|sun55i)"
 
 DEFAULT_PREFERENCE:sun4i = "1"
 DEFAULT_PREFERENCE:sun5i = "1"
 DEFAULT_PREFERENCE:sun7i = "1"
 DEFAULT_PREFERENCE:sun8i = "1"
 DEFAULT_PREFERENCE:sun50i = "1"
+DEFAULT_PREFERENCE:sun55i = "1"
 
 SRC_URI:append:sunxi = " \
     file://0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch \
@@ -32,8 +34,10 @@ UBOOT_ENV:sunxi = "boot"
 
 EXTRA_OEMAKE:append:sunxi = ' HOSTLDSHARED="${BUILD_CC} -shared ${BUILD_LDFLAGS} ${BUILD_CFLAGS}" '
 EXTRA_OEMAKE:append:sun50i = " BL31=${DEPLOY_DIR_IMAGE}/trusted-firmware-a/bl31.bin SCP=/dev/null"
+EXTRA_OEMAKE:append:sun55i = " BL31=${DEPLOY_DIR_IMAGE}/trusted-firmware-a/bl31.bin SCP=/dev/null"
 
 do_compile:sun50i[depends] += "trusted-firmware-a:do_deploy"
+do_compile:sun55i[depends] += "trusted-firmware-a:do_deploy"
 
 do_compile:append:sunxi() {
     ${UBOOT_MKIMAGE} -C none -A arm -T script -d ${UNPACKDIR}/boot.cmd ${UNPACKDIR}/${UBOOT_ENV_BINARY}

--- a/recipes-kernel/linux/linux-mainline.inc
+++ b/recipes-kernel/linux/linux-mainline.inc
@@ -38,6 +38,8 @@ SRC_URI:append = " \
 	file://patches/0004-dts-allwinner-bananapi-m64-Consistent-nodes-for-mmc-devices.patch \
 	file://patches/0005-ARM-dts-sunxi-Add-MMC-alias-for-consistent-enumerati.patch \
 	file://patches/0006-dts-allwinner-orangepi-zero-mmc-aliases-for-consiste.patch \
+	file://patches/0001-arm64-dts-allwinner-a523-add-gmac200-ethernet-controller.patch \
+	file://patches/0001-arm64-dts-allwinner-orangepi-4a-enable-gmac200.patch \
 "
 
 SRC_URI:append:use-mailine-graphics = " file://drm.cfg"

--- a/recipes-kernel/linux/linux-mainline.inc
+++ b/recipes-kernel/linux/linux-mainline.inc
@@ -1,7 +1,7 @@
 SECTION = "kernel"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
-COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i|sun9i|sun50i)"
+COMPATIBLE_MACHINE = "(sun4i|sun5i|sun7i|sun8i|sun9i|sun50i|sun55i)"
 
 inherit kernel
 
@@ -45,6 +45,8 @@ SRC_URI:append:bananapi = " file://axp20x.cfg"
 SRC_URI:append:bananapi-m2-berry = " file://axp20x.cfg"
 SRC_URI:append:bananapi-m2-zero = " file://axp20x.cfg"
 SRC_URI:append:cubietruck = " file://axp20x.cfg"
+SRC_URI:append:orange-pi-4a = " file://axp20x.cfg \
+								file://ext4.cfg"
 SRC_URI:append:nanopi-neo-air = " file://cam500b.cfg"
 SRC_URI:append:orange-pi-prime = " \
 	file://0001-dts-sun50i-h5-enable-power-button-for-orange-pi-prime.patch \

--- a/recipes-kernel/linux/linux-mainline/ext4.cfg
+++ b/recipes-kernel/linux/linux-mainline/ext4.cfg
@@ -1,0 +1,1 @@
+CONFIG_EXT4_FS=y

--- a/recipes-kernel/linux/linux-mainline/patches/0001-arm64-dts-allwinner-a523-add-gmac200-ethernet-controller.patch
+++ b/recipes-kernel/linux/linux-mainline/patches/0001-arm64-dts-allwinner-a523-add-gmac200-ethernet-controller.patch
@@ -1,0 +1,94 @@
+From 460a71b5642a60574809032f0a21afff0f942474 Mon Sep 17 00:00:00 2001
+From: Chen-Yu Tsai <wens@csie.org>
+Date: Tue, 23 Sep 2025 22:02:43 +0800
+Subject: [PATCH] arm64: dts: allwinner: a523: Add GMAC200 ethernet controller
+
+The A523 SoC family has a second ethernet controller, called the
+GMAC200. It is not exposed on all the SoCs in the family.
+
+Add a device node for it. All the hardware specific settings are from
+the vendor BSP.
+
+Acked-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+Link: https://patch.msgid.link/20250923140247.2622602-4-wens@kernel.org
+Signed-off-by: Chen-Yu Tsai <wens@csie.org>
+
+Upstream-Status: Backport [https://github.com/torvalds/linux/commit/460a71b5642a60574809032f0a21afff0f942474]
+Signed-off-by: Dmitry Sakhonchik <frezidok1@gmail.com>
+---
+ .../arm64/boot/dts/allwinner/sun55i-a523.dtsi | 55 +++++++++++++++++++
+ 1 file changed, 55 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
+index 7b36c47a3a1399..a9e051a8bea3fd 100644
+--- a/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun55i-a523.dtsi
+@@ -182,6 +182,16 @@
+ 				bias-disable;
+ 			};
+ 
++			rgmii1_pins: rgmii1-pins {
++				pins = "PJ0", "PJ1", "PJ2", "PJ3", "PJ4",
++				       "PJ5", "PJ6", "PJ7", "PJ8", "PJ9",
++				       "PJ11", "PJ12", "PJ13", "PJ14", "PJ15";
++				allwinner,pinmux = <5>;
++				function = "gmac1";
++				drive-strength = <40>;
++				bias-disable;
++			};
++
+ 			uart0_pb_pins: uart0-pb-pins {
+ 				pins = "PB9", "PB10";
+ 				allwinner,pinmux = <2>;
+@@ -603,6 +613,51 @@
+ 			};
+ 		};
+ 
++		gmac1: ethernet@4510000 {
++			compatible = "allwinner,sun55i-a523-gmac200",
++				     "snps,dwmac-4.20a";
++			reg = <0x04510000 0x10000>;
++			clocks = <&ccu CLK_BUS_EMAC1>, <&ccu CLK_MBUS_EMAC1>;
++			clock-names = "stmmaceth", "mbus";
++			resets = <&ccu RST_BUS_EMAC1>;
++			reset-names = "stmmaceth";
++			interrupts = <GIC_SPI 47 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "macirq";
++			pinctrl-names = "default";
++			pinctrl-0 = <&rgmii1_pins>;
++			power-domains = <&pck600 PD_VO1>;
++			syscon = <&syscon>;
++			snps,fixed-burst;
++			snps,axi-config = <&gmac1_stmmac_axi_setup>;
++			snps,mtl-rx-config = <&gmac1_mtl_rx_setup>;
++			snps,mtl-tx-config = <&gmac1_mtl_tx_setup>;
++			status = "disabled";
++
++			mdio1: mdio {
++				compatible = "snps,dwmac-mdio";
++				#address-cells = <1>;
++				#size-cells = <0>;
++			};
++
++			gmac1_mtl_rx_setup: rx-queues-config {
++				snps,rx-queues-to-use = <1>;
++
++				queue0 {};
++			};
++
++			gmac1_stmmac_axi_setup: stmmac-axi-config {
++				snps,wr_osr_lmt = <0xf>;
++				snps,rd_osr_lmt = <0xf>;
++				snps,blen = <256 128 64 32 16 8 4>;
++			};
++
++			gmac1_mtl_tx_setup: tx-queues-config {
++				snps,tx-queues-to-use = <1>;
++
++				queue0 {};
++			};
++		};
++
+ 		ppu: power-controller@7001400 {
+ 			compatible = "allwinner,sun55i-a523-ppu";
+ 			reg = <0x07001400 0x400>;

--- a/recipes-kernel/linux/linux-mainline/patches/0001-arm64-dts-allwinner-orangepi-4a-enable-gmac200.patch
+++ b/recipes-kernel/linux/linux-mainline/patches/0001-arm64-dts-allwinner-orangepi-4a-enable-gmac200.patch
@@ -1,0 +1,70 @@
+From a3606e8a7819534026b46e2b8c7b0e156e292f13 Mon Sep 17 00:00:00 2001
+From: Chen-Yu Tsai <wens@csie.org>
+Date: Tue, 23 Sep 2025 22:02:46 +0800
+Subject: [PATCH] arm64: dts: allwinner: t527: orangepi-4a: Enable Ethernet
+ port
+
+On the Orangepi 4A board, the second Ethernet controller, aka the GMAC200,
+is connected to an external Motorcomm YT8531 PHY. The PHY uses an external
+25MHz crystal, has the SoC's PI15 pin connected to its reset pin, and
+the PI16 pin for its interrupt pin.
+
+Enable it.
+
+Acked-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Link: https://patch.msgid.link/20250923140247.2622602-7-wens@kernel.org
+Signed-off-by: Chen-Yu Tsai <wens@csie.org>
+
+Upstream-Status: Backport [https://github.com/torvalds/linux/commit/a3606e8a7819534026b46e2b8c7b0e156e292f13]
+Signed-off-by: Dmitry Sakhonchik <frezidok1@gmail.com>
+---
+ .../dts/allwinner/sun55i-t527-orangepi-4a.dts | 23 +++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun55i-t527-orangepi-4a.dts b/arch/arm64/boot/dts/allwinner/sun55i-t527-orangepi-4a.dts
+index 39a4e194712a28..9e6b21cf293ee7 100644
+--- a/arch/arm64/boot/dts/allwinner/sun55i-t527-orangepi-4a.dts
++++ b/arch/arm64/boot/dts/allwinner/sun55i-t527-orangepi-4a.dts
+@@ -15,6 +15,7 @@
+ 	compatible = "xunlong,orangepi-4a", "allwinner,sun55i-t527";
+ 
+ 	aliases {
++		ethernet0 = &gmac1;
+ 		serial0 = &uart0;
+ 	};
+ 
+@@ -102,11 +103,33 @@
+ 	status = "okay";
+ };
+ 
++&gmac1 {
++	phy-mode = "rgmii-id";
++	phy-handle = <&ext_rgmii_phy>;
++	phy-supply = <&reg_cldo4>;
++
++	tx-internal-delay-ps = <0>;
++	rx-internal-delay-ps = <300>;
++
++	status = "okay";
++};
++
+ &gpu {
+ 	mali-supply = <&reg_dcdc2>;
+ 	status = "okay";
+ };
+ 
++&mdio1 {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <1>;
++		interrupts-extended = <&pio 8 16 IRQ_TYPE_LEVEL_LOW>; /* PI16 */
++		reset-gpios = <&pio 8 15 GPIO_ACTIVE_LOW>; /* PI15 */
++		reset-assert-us = <10000>;
++		reset-deassert-us = <150000>;
++	};
++};
++
+ &mmc0 {
+ 	vmmc-supply = <&reg_cldo3>;
+ 	cd-gpios = <&pio 5 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; /* PF6 */


### PR DESCRIPTION
Add Orange Pi 4A and sun55i soc family support. 

Due to absence of upstream TF-A support, use Jernej Skrabec's fork.
It's pretty stable and in the upstreaming process right now.

Tested on Orange Pi 4A 2 GiB:

- TF-A and U-Boot:    working
- Linux SD Card boot: working
- USB:                working
- Ethernet:           working 
- Wi-Fi SDIO device:  detected, firmware missing
- eMMC:               detected, but access produces I/O errors (seems to be upstream problem)
- Bluetooth:          not working

Depends on #465 